### PR TITLE
remove unused babel-cli, move babel-core to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "license": "MIT",
   "main": "./flush.js",
   "dependencies": {
-    "babel": "^6.5.2",
-    "babel-core": "^6.18.2",
     "babel-plugin-syntax-jsx": "^6.18.0"
   },
   "devDependencies": {
     "ava": "^0.17.0",
-    "babel-cli": "^6.18.0",
+    "babel-core": "^6.18.2",
     "babel-preset-es2015": "^6.16.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-react": "^6.16.0",


### PR DESCRIPTION
The `babel` npm package currently doesn't do anything (you usually mean to install babel-cli).

`babel-core` is only used in the tests https://github.com/zeit/styled-jsx/blob/master/test/index.js#L5 so can be a devDep as well

And I didn't see babel-cli referenced anywhere?