### PR TITLE
Correct place of Ember community

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This is useful for performing diffs of elements between top-level `render()` cal
 - **Sunil Pai** ([glamor](https://github.com/threepointone/glamor)) inspired the use of `murmurhash2` (minimal and fast hashing) and an efficient style injection logic.
 - **Sultan Tarimo** built [stylis.js](https://github.com/thysultan), a super fast and tiny CSS parser and compiler.
 - **Max Stoiber** ([styled-components](https://github.com/styled-components)) proved the value of retaining the familiarity of CSS syntax and pointed me to the very efficient [stylis](https://github.com/thysultan/stylis.js) compiler (which we forked to very efficiently append attribute selectors to the user's css)
-- **Yehuda Katz** ([ember](https://github.com/ember)) convinced me on Twitter to transpile CSS as an alternative to CSS-in-JS.
+- **Yehuda Katz** ([ember](https://github.com/emberjs)) convinced me on Twitter to transpile CSS as an alternative to CSS-in-JS.
 - **Evan You** ([vuejs](https://github.com/vuejs)) discussed his Vue.js CSS transformation with me.
 - **Henry Zhu** ([babel](https://github.com/babel)) helpfully pointed me to some important areas of the babel plugin API.
 


### PR DESCRIPTION
Ember community is github.com/emberjs not github.com/ember.