### PR TITLE
Better SSR methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ export default () => (
 
 The main export flushes your styles to an array of `React.Element`:
 
-```
+```js
 import React from 'react'
 import ReactDOM from 'react-dom/server'
 import flush from 'styled-jsx/server'
 import App from './app'
-// …
+
 export default (req, res) => {
   const app = ReactDOM.renderToString(<App />)
   const styles = flush()

--- a/README.md
+++ b/README.md
@@ -146,6 +146,57 @@ export default () => (
 
 ## Server-Side Rendering
 
+### `styled-jsx/server`
+
+The main export flushes your styles to an array of `React.Element`:
+
+```
+import React from 'react'
+import ReactDOM from 'react-dom/server'
+import flush from 'styled-jsx/server'
+import App from './app'
+// …
+export default (req, res) => {
+  const app = ReactDOM.renderToString(<App />)
+  const styles = flush()
+  const html = ReactDOM.renderToStaticMarkup(<html>
+    <head>{ styles }</head>
+    <body>
+      <div id="root" dangerouslySetInnerHTML={{__html: app}} />
+    </body>
+  </html>)
+  res.end('<!doctype html>' + html)
+}
+```
+
+We also expose `flushToHTML` to return generated HTML:
+
+```js
+import React from 'react'
+import ReactDOM from 'react-dom/server'
+import { flushToHTML } from 'styled-jsx/server'
+import App from './app'
+
+export default (req, res) => {
+  const app = ReactDOM.renderToString(<App />)
+  const styles = flushToString()
+  const html = `<!doctype html>
+    <html>
+      <head>${styles}</head>
+      <body>
+        <div id="root">${app}</div>
+      </body>
+    </html>`
+  res.end(html)
+}
+```
+
+It's **paramount** that you use one of these two functions so that
+the generated styles can be diffed when the client loads and
+duplicate styles are avoided.
+
+### `styled-jsx/flush`
+
 In the server rendering pipeline, you can obtain the entire CSS of all components by invoking `flush`:
 
 ```js

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -13,7 +13,7 @@ gulp.task('transpile', () => {
 })
 
 gulp.task('runtime-size', async () => {
-  const files = ['flush.js', 'memory.js', 'render.js', 'style.js']
+  const files = ['flush.js', 'server.js', 'memory.js', 'render.js', 'style.js']
 
   const result = await Promise.all(files
   .map(f => join(__dirname, 'src', f))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "dist",
     "lib",
+    "server.js",
     "babel.js",
     "flush.js",
     "memory.js",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "human-size": "^1.1.0",
     "mz": "^2.6.0",
     "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "xo": "^0.17.1"
   },
   "peerDependencies": {

--- a/src/render.js
+++ b/src/render.js
@@ -30,9 +30,16 @@ function diff(a, b) {
   return [added, removed]
 }
 
+const fromServer = {}
+
 function patch([added, removed]) {
   for (const [id, c] of added) {
-    tags[id] = makeStyleTag(c.props.css)
+    // avoid duplicates from server-rendered markup
+    if (undefined === fromServer[id]) {
+      fromServer[id] = document.getElementById(`__jsx-style-${id}`)
+    }
+
+    tags[id] = fromServer[id] || makeStyleTag(c.props.css)
   }
 
   for (const [id] of removed) {

--- a/src/render.js
+++ b/src/render.js
@@ -46,6 +46,8 @@ function patch([added, removed]) {
     const t = tags[id]
     delete tags[id]
     t.parentNode.removeChild(t)
+    // avoid checking the DOM later on
+    fromServer[id] = null
   }
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -45,8 +45,6 @@ function patch([added, removed]) {
 function makeStyleTag(str) {
   // based on implementation by glamor
   const tag = document.createElement('style')
-
-  tag.type = 'text/css'
   tag.appendChild(document.createTextNode(str))
 
   const head = document.head || document.getElementsByTagName('head')[0]

--- a/src/server.js
+++ b/src/server.js
@@ -1,27 +1,33 @@
 import React from 'react'
 import flush from './flush'
 
-export default function flushToReact () {
+const {hasOwnProperty} = Object.prototype
+
+export default function flushToReact() {
   const mem = flush()
   const arr = []
   for (const id in mem) {
-    arr.push(React.createElement('style', {
-      id: `__jsx-style-${id}`,
-      // avoid warnings upon render with a key
-      key: `__jsx-style-${id}`,
-      dangerouslySetInnerHTML: {
-        __html: mem[id]
-      }
-    }))
+    if (hasOwnProperty.call(mem, id)) {
+      arr.push(React.createElement('style', {
+        id: `__jsx-style-${id}`,
+        // avoid warnings upon render with a key
+        key: `__jsx-style-${id}`,
+        dangerouslySetInnerHTML: {
+          __html: mem[id]
+        }
+      }))
+    }
   }
   return arr
 }
 
-export function flushToHTML () {
+export function flushToHTML() {
   const mem = flush()
   let html = ''
   for (const id in mem) {
-    html += `<style id="__jsx-style-${id}">${mem[id]}</style>`
+    if (hasOwnProperty.call(mem, id)) {
+      html += `<style id="__jsx-style-${id}">${mem[id]}</style>`
+    }
   }
   return html
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import flush from './flush'
+
+export default function flushToReact () {
+  const mem = flush()
+  const arr = []
+  for (const id in mem) {
+    arr.push(React.createElement('style', {
+      id: `__jsx-style-${id}`,
+      // avoid warnings upon render with a key
+      key: `__jsx-style-${id}`,
+      dangerouslySetInnerHTML: {
+        __html: mem[id]
+      }
+    }))
+  }
+  return arr
+}
+
+export function flushToHTML () {
+  const mem = flush()
+  let html = ''
+  for (const id in mem) {
+    html += `<style id="__jsx-style-${id}">${mem[id]}</style>`
+  }
+  return html
+}

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ import ReactDOM from 'react-dom/server'
 // Ours
 import plugin from '../src/babel'
 import JSXStyle from '../src/style'
-import flush, { flushToHTML } from '../src/server'
+import flush, {flushToHTML} from '../src/server'
 import read from './_read'
 
 const transform = (file, opts = {}) => (
@@ -77,7 +77,7 @@ test('works with multiple jsx blocks', async t => {
 })
 
 test('server rendering', t => {
-  function App () {
+  function App() {
     return React.createElement('div', null,
       React.createElement(JSXStyle, {
         css: 'p { color: red }',
@@ -91,8 +91,8 @@ test('server rendering', t => {
   }
 
   // expected CSS
-  const expected = '<style id="__jsx-style-1">p { color: red }</style>'
-    + '<style id="__jsx-style-2">div { color: blue }</style>'
+  const expected = '<style id="__jsx-style-1">p { color: red }</style>' +
+    '<style id="__jsx-style-2">div { color: blue }</style>'
 
   // render using react
   ReactDOM.renderToString(React.createElement(App))

--- a/test/index.js
+++ b/test/index.js
@@ -4,9 +4,13 @@ import path from 'path'
 // Packages
 import test from 'ava'
 import {transformFile} from 'babel-core'
+import React from 'react'
+import ReactDOM from 'react-dom/server'
 
 // Ours
 import plugin from '../src/babel'
+import JSXStyle from '../src/style'
+import flush, { flushToHTML } from '../src/server'
 import read from './_read'
 
 const transform = (file, opts = {}) => (
@@ -70,4 +74,42 @@ test('works with multiple jsx blocks', async t => {
   const {code} = await transform('./fixtures/multiple-jsx.js')
   const out = await read('./fixtures/multiple-jsx.out.js')
   t.is(code, out.trim())
+})
+
+test('server rendering', t => {
+  function App () {
+    return React.createElement('div', null,
+      React.createElement(JSXStyle, {
+        css: 'p { color: red }',
+        styleId: 1
+      }),
+      React.createElement(JSXStyle, {
+        css: 'div { color: blue }',
+        styleId: 2
+      })
+    )
+  }
+
+  // expected CSS
+  const expected = '<style id="__jsx-style-1">p { color: red }</style>'
+    + '<style id="__jsx-style-2">div { color: blue }</style>'
+
+  // render using react
+  ReactDOM.renderToString(React.createElement(App))
+  const html = ReactDOM.renderToStaticMarkup(
+    React.createElement('head', null, flush())
+  )
+  t.is(html, `<head>${expected}</head>`)
+
+  // assert that memory is empty
+  t.is(0, flush().length)
+  t.is('', flushToHTML())
+
+  // render to html again
+  ReactDOM.renderToString(React.createElement(App))
+  t.is(expected, flushToHTML())
+
+  // assert that memory is empty
+  t.is(0, flush().length)
+  t.is('', flushToHTML())
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,7 +1900,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz#bd33145744519ab1c36c3ee9f31f08e9079b67f2"
 
-fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.6.tgz#7eb67d6986b2d5007a9b6e92e0e7cb6f75cad290"
   dependencies:
@@ -3735,6 +3735,14 @@ rc@^1.0.1, rc@^1.1.6, rc@~1.1.6:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
+
+react-dom@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.1.tgz#d54c913261aaedb17adc20410d029dcc18a1344a"
+  dependencies:
+    fbjs "^0.8.1"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
 
 react@^15.4.1:
   version "15.4.1"


### PR DESCRIPTION
Fixes #22 

- Adds `styled-jsx/server`
  - `flush()` (`default`) returns an array of `React.Element` for each `<style>`
  - `flushToHTML` returns an HTML string

Additionally

- Both new methods include an `id` in the resulting `<style>` that the client rendering part can use to de-dupe. 
- The de-duping logic only checks the DOM once and works transparently, without manual initialization by the user