### PR TITLE
Switch from rAF to Promise to fix FOUC in Safari

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -3,7 +3,7 @@ import render from './render'
 
 const update = typeof window === 'undefined' ? doRender : updateOnClient
 let components = []
-let requestId
+let updatePromise
 
 export default class extends Component {
   componentWillMount() {
@@ -51,10 +51,14 @@ function unmount(component) {
 }
 
 function updateOnClient() {
-  window.cancelAnimationFrame(requestId)
-  requestId = window.requestAnimationFrame(() => {
-    requestId = null
-    doRender()
+  // Debounce calls and only render once the latest promise resolves.
+  // rAF causes FOUC in Safari, setTimeout causes FOUC in Chrome, Promise#then()
+  // ensures micro task enqueuing of styles update before paint.
+  const promise = updatePromise = Promise.resolve().then(() => {
+    if (promise === updatePromise) {
+      updatePromise = null
+      doRender()
+    }
   })
 }
 


### PR DESCRIPTION
This fixes the FOUC issue in Safari by switching from `requestAnimationFrame()` to `Promise#then()` for the debouncing/batching mechanism. `requestAnimationFrame()` causes FOUC in Safari, `setTimeout()` causes FOUC in Chrome, while `Promise#then()` ensures micro task enqueueing of styles update before paint in Safari, Chrome, and Firefox.

This maintains the same semantics where only the latest call to `updateOnClient()` causes the rendering of styles by "cancelling" the previously created promises by making them noops.

Fixes #52
/cc @rauchg @nkzawa 