### PR TITLE
Fix transform exits when it finds a block without styles

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -100,9 +100,6 @@ export default function ({types: t}) {
           const styles = findStyles(path.node.children)
 
           if (styles.length === 0) {
-            if (state.file.hasJSXStyle) {
-              state.hasJSXStyle = false
-            }
             return
           }
 

--- a/test/fixtures/multiple-jsx.js
+++ b/test/fixtures/multiple-jsx.js
@@ -1,6 +1,18 @@
-const Test = () => <span>test</span>
+const Test1 = () => (
+  <div>
+    <span>test</span>
+    <Component />
+    <style jsx>{`
+      span {
+        color: red;
+      }
+    `}</style>
+  </div>
+)
 
-const Test2 = () => (
+const Test2 = () => <span>test</span>
+
+const Test3 = () => (
   <div>
     <span>test</span>
     <style jsx>{`

--- a/test/fixtures/multiple-jsx.out.js
+++ b/test/fixtures/multiple-jsx.out.js
@@ -1,7 +1,13 @@
 import _JSXStyle from "styled-jsx/style";
-const Test = () => <span>test</span>;
+const Test1 = () => <div data-jsx={1535297024}>
+    <span data-jsx={1535297024}>test</span>
+    <Component data-jsx={1535297024} />
+    <_JSXStyle styleId={1535297024} css={"span[data-jsx=\"1535297024\"] {color: red;}"} />
+  </div>;
 
-const Test2 = () => <div data-jsx={1535297024}>
+const Test2 = () => <span>test</span>;
+
+const Test3 = () => <div data-jsx={1535297024}>
     <span data-jsx={1535297024}>test</span>
     <_JSXStyle styleId={1535297024} css={"span[data-jsx=\"1535297024\"] {color: red;}"} />
   </div>;


### PR DESCRIPTION
fixes zeit/next.js/issues/481