### PR TITLE
Fix potential double MARKUP_ATTRIBUTE attribution

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -80,7 +80,7 @@ export default function ({types: t}) {
           name.charAt(0) !== name.charAt(0).toUpperCase()
         ) {
           for (const attr of el.attributes) {
-            if (attr.name === MARKUP_ATTRIBUTE) {
+            if (attr.name === MARKUP_ATTRIBUTE || attr.name.name === MARKUP_ATTRIBUTE) {
               // avoid double attributes
               return
             }


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/743

Since we set the MARKUP_ATTRIBUTE as a `JSXIdentifier`, name field of the attribute can be an object.