### PR TITLE
Skip non-styled-jsx style elements

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -281,14 +281,13 @@ export default function ({types: t}) {
           // next visit will be: JSXOpeningElement
         },
         exit(path, state) {
-          const el = path.node.openingElement
-          const isGlobal = isGlobalEl(el)
+          const isGlobal = isGlobalEl(path.node.openingElement)
 
           if (state.hasJSXStyle && (!--state.ignoreClosing && !isGlobal)) {
             state.hasJSXStyle = null
           }
 
-          if (!state.hasJSXStyle || !el.name || el.name.name !== 'style') {
+          if (!state.hasJSXStyle || !isStyledJsx(path)) {
             return
           }
 

--- a/test/fixtures/non-styled-jsx-style.js
+++ b/test/fixtures/non-styled-jsx-style.js
@@ -1,0 +1,7 @@
+export default () => (
+  <div>
+    <p>woot</p>
+    <style dangerouslySetInnerHTML={{ __html: `body: { margin: 0; }` }}></style>
+    <style jsx>{'p { color: red }'}</style>
+  </div>
+)

--- a/test/fixtures/non-styled-jsx-style.js
+++ b/test/fixtures/non-styled-jsx-style.js
@@ -1,7 +1,7 @@
 export default () => (
   <div>
     <p>woot</p>
-    <style dangerouslySetInnerHTML={{ __html: `body: { margin: 0; }` }}></style>
+    <style dangerouslySetInnerHTML={{ __html: `body { margin: 0; }` }}></style>
     <style jsx>{'p { color: red }'}</style>
   </div>
 )

--- a/test/fixtures/non-styled-jsx-style.out.js
+++ b/test/fixtures/non-styled-jsx-style.out.js
@@ -1,0 +1,6 @@
+import _JSXStyle from 'styled-jsx/style';
+export default (() => <div data-jsx={188072295}>
+    <p data-jsx={188072295}>woot</p>
+    <style dangerouslySetInnerHTML={{ __html: `body: { margin: 0; }` }}></style>
+    <_JSXStyle styleId={188072295} css={"p[data-jsx=\"188072295\"] {color: red }"} />
+  </div>);

--- a/test/fixtures/non-styled-jsx-style.out.js
+++ b/test/fixtures/non-styled-jsx-style.out.js
@@ -1,6 +1,6 @@
 import _JSXStyle from 'styled-jsx/style';
 export default (() => <div data-jsx={188072295}>
     <p data-jsx={188072295}>woot</p>
-    <style dangerouslySetInnerHTML={{ __html: `body: { margin: 0; }` }}></style>
+    <style dangerouslySetInnerHTML={{ __html: `body { margin: 0; }` }}></style>
     <_JSXStyle styleId={188072295} css={"p[data-jsx=\"188072295\"] {color: red }"} />
   </div>);

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,12 @@ test('works with expressions in template literals', async t => {
   t.is(code, out.trim())
 })
 
+test('works with non styled-jsx styles', async t => {
+  const {code} = await transform('./fixtures/non-styled-jsx-style.js')
+  const out = await read('./fixtures/non-styled-jsx-style.out.js')
+  t.is(code, out.trim())
+})
+
 test('throws when using `props` or constants ' +
   'defined in the closest scope', async t => {
   [1, 2, 3, 4].forEach(i => {


### PR DESCRIPTION
This PR fixes errors happen when there is a non-styled-jsx style element.