### PR TITLE
isSafari should include webviews

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -8,7 +8,7 @@ let updatePromise
 // includes desktop and iOS, based on
 // https://github.com/DamonOehlman/detect-browser/blob/master/lib/detectBrowser.js
 const isSafari = typeof window === 'undefined' ?
-  false : /Version\/[0-9._]+.*Safari/.test(window.navigator.userAgent)
+  false : /(Version\/[0-9._]+.*Safari|(iPhone|iPod|iPad).*AppleWebKit)/.test(window.navigator.userAgent)
 
 export default class extends Component {
   componentWillMount() {


### PR DESCRIPTION
I was pulling my hair for a while with this issue, until I noticed that this bug was recently [fixed](https://github.com/zeit/styled-jsx/pull/102) but the browser sniffing was not including iOS webviews.