### PR TITLE
Fix expr namespacing inside animation shorthand

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -102,11 +102,11 @@ export default function ({types: t}) {
     // e.g.
     // p { color: ${myConstant}; }
     // becomes
-    // p { color: ___styledjsxexpression0___; }
+    // p { color: 0__styledjsxexpression_0__0; }
 
     const replacements = expressions.map((e, id) => ({
       pattern: new RegExp(`\\$\\{\\s*${escapeStringRegExp(e.getSource())}\\s*\\}`),
-      replacement: `___styledjsxexpression_${id}___`,
+      replacement: `0__styledjsxexpression_${id}__0`,
       initial: `$\{${e.getSource()}}`
     })).sort((a, b) => a.initial.length < b.initial.length)
 

--- a/src/babel.js
+++ b/src/babel.js
@@ -102,11 +102,11 @@ export default function ({types: t}) {
     // e.g.
     // p { color: ${myConstant}; }
     // becomes
-    // p { color: 0__styledjsxexpression_0__0; }
+    // p { color: %%styledjsxexpression_0%%; }
 
     const replacements = expressions.map((e, id) => ({
       pattern: new RegExp(`\\$\\{\\s*${escapeStringRegExp(e.getSource())}\\s*\\}`),
-      replacement: `0__styledjsxexpression_${id}__0`,
+      replacement: `%%styledjsxexpression_${id}%%`,
       initial: `$\{${e.getSource()}}`
     })).sort((a, b) => a.initial.length < b.initial.length)
 

--- a/test/fixtures/expressions.js
+++ b/test/fixtures/expressions.js
@@ -24,7 +24,7 @@ export default () => (
     }</style>
     <style jsx>{`p { animation-duration: ${animationDuration} }`}</style>
     <style jsx>{`
-      p { animation: ${animationDuration} forwards ${animationName } }`
+      p { animation: ${animationDuration} forwards ${animationName} }`
     }</style>
   </div>
 )

--- a/test/fixtures/expressions.js
+++ b/test/fixtures/expressions.js
@@ -2,6 +2,7 @@ const color = 'red'
 const otherColor = 'green'
 const mediumScreen = '680px'
 const animationDuration = '200ms'
+const animationName = 'my-cool-animation'
 
 export default () => (
   <div>
@@ -22,5 +23,8 @@ export default () => (
       p { color: red }`
     }</style>
     <style jsx>{`p { animation-duration: ${animationDuration} }`}</style>
+    <style jsx>{`
+      p { animation: ${animationDuration} forwards ${animationName } }`
+    }</style>
   </div>
 )


### PR DESCRIPTION
Changes the placeholder for expressions to avoid namespacing non
`animation-name` strings when using them inside `animation` shorthand.

Problem with actual code is that it replaces temporarily every found expression with
`__styledjsxexpression_${id}__`. This is OK in almost every CSS property... but nope in
`animation` shorthand. Because, if you use and expressión to set a value different than
the `animation-name`, stylis.js will namespace it, thinking it's an `animation-name`.
Because the resulting string is a valid `animation-name` string. I just add a zero at the beginning of the placeholder because, that way, it isn't a valid `animation-name`, so stylis.js won't namespace it.
And everything else works. I added another zero at the end because, you know: symmetry.

As example, from my own code, this:

```js
 .active {
  animation: ${USER_TONE_FADE_DURATION}s forwards user-activated;
}
```

will render like this:

```js
.active[data-jsx="2540933619"] {
  ...
  animation: a25409336190.5s forwards a2540933619user-activated;
}
```

And well, the animation will be wrong-formed and won't be applied.

Of course, you can easily avoid this bug by not using the shorthand property.
But the shorthand is nice and it's there to use it when you want, right?

**Note**: it's there any prize 🥇 for a dumb PR, because I know this deserve it ^_^U.

I suspect (xD) this is hideous and ugly xD, but it's a quick & easy patch from someone not familiar with this project.
IDK if this is OK, but sure this is a problem that should be tackled, so here is my quick try :þ.

**Note 2**: there was also a little errata into the original code comment, because `___styledjsxexpression0___`, wich, according to the original placeholder, should be `___styledjsxexpression_0___`.