### PR TITLE
Add Syntax Highlighting Solution for VS Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -305,6 +305,14 @@ You get full CSS highlighting and autocompletion and it will last until you clos
 }
 ```
 
+### [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=blanu.vscode-styled-jsx)
+Launch VS Code Quick Open (⌘+P), paste the following command, and press enter.
+```
+ext install vscode-styled-jsx
+```
+#### Autocomplete
+By now, this extension doesn't support autocomplete. However, you can install [ES6 Template Literal Editor](https://marketplace.visualstudio.com/items?itemName=plievone.vscode-template-literal-editor) extension to edit styles in another pane, and you will get full feature of css language service provided by VS Code.
+
 ## Credits
 
 - **Pedram Emrouznejad** ([rijs](https://github.com/rijs/fullstack)) suggested attribute selectors over my initial class prefixing idea.


### PR DESCRIPTION
I wrote a extension for highlighting styled-jsx in .js or .jsx file. Hope it's useful. Close #161.