### PR TITLE
Fix HMR not updating style

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -19,13 +19,13 @@ function diff(a, b) {
 const fromServer = new Map()
 
 function patch([added, removed]) {
-  for (const [id, c] of added) {
+  for (const [id, css] of added) {
     // Avoid duplicates from server-rendered markup
     if (!fromServer.has(id)) {
       fromServer.set(id, document.getElementById(`__jsx-style-${id}`))
     }
 
-    const tag = fromServer.get(id) || makeStyleTag(c.props.css)
+    const tag = fromServer.get(id) || makeStyleTag(css)
     tags.set(id, tag)
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -4,14 +4,14 @@ import { flush } from './style'
 export default function flushToReact() {
   const mem = flush()
   const arr = []
-  for (const [id, c] of mem) {
+  for (const [id, css] of mem) {
     arr.push(
       React.createElement('style', {
         id: `__jsx-style-${id}`,
         // Avoid warnings upon render with a key
         key: `__jsx-style-${id}`,
         dangerouslySetInnerHTML: {
-          __html: c.props.css
+          __html: css
         }
       })
     )
@@ -22,8 +22,8 @@ export default function flushToReact() {
 export function flushToHTML() {
   const mem = flush()
   let html = ''
-  for (const [id, c] of mem) {
-    html += `<style id="__jsx-style-${id}">${c.props.css}</style>`
+  for (const [id, css] of mem) {
+    html += `<style id="__jsx-style-${id}">${css}</style>`
   }
   return html
 }

--- a/src/style.js
+++ b/src/style.js
@@ -8,7 +8,7 @@ export default class extends Component {
     mount(this)
   }
 
-  componentWillUpdate() {
+  componentDidUpdate() {
     update()
   }
 

--- a/src/style.js
+++ b/src/style.js
@@ -8,8 +8,12 @@ export default class extends Component {
     mount(this)
   }
 
-  componentDidUpdate() {
-    update()
+  componentWillUpdate(nextProps) {
+    update({
+      instance: this,
+      id: nextProps.styleId,
+      css: nextProps.css
+    })
   }
 
   componentWillUnmount() {
@@ -21,16 +25,22 @@ export default class extends Component {
   }
 }
 
-function componentMap() {
+function styleMap(updated) {
   const ret = new Map()
   for (const c of components) {
-    ret.set(c.props.styleId, c)
+    if (updated && c === updated.instance) {
+      // Use styleId and css from upated component rather than reading props
+      // from the component since they haven't been updated yet
+      ret.set(updated.styleId, updated.css)
+    } else {
+      ret.set(c.props.styleId, c.props.css)
+    }
   }
   return ret
 }
 
 export function flush() {
-  const ret = componentMap()
+  const ret = styleMap()
   components = []
   return ret
 }
@@ -50,6 +60,6 @@ function unmount(component) {
   update()
 }
 
-function update() {
-  render(componentMap())
+function update(updates) {
+  render(styleMap(updates))
 }

--- a/src/style.js
+++ b/src/style.js
@@ -11,7 +11,7 @@ export default class extends Component {
   componentWillUpdate(nextProps) {
     update({
       instance: this,
-      id: nextProps.styleId,
+      styleId: nextProps.styleId,
       css: nextProps.css
     })
   }

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`generates source maps 1`] = `
 export default (() => <div data-jsx={188072295}>
     <p data-jsx={188072295}>test</p>
     <p data-jsx={188072295}>woot</p>
-    <_JSXStyle styleId={188072295} css={\\"p[data-jsx=\\\\\\"188072295\\\\\\"]{color:red}\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFdBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"} />
+    <_JSXStyle styleId={188072295} css={\\"p[data-jsx=\\\\\\"188072295\\\\\\"]{color:red}\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsImZpbGUiOiJzb3VyY2UtbWFwcy5qcyIsInNvdXJjZXNDb250ZW50IjpbXX0= */\\\\n/*@ sourceURL=source-maps.js */\\"} />
   </div>);"
 `;
 

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`generates source maps 1`] = `
 export default (() => <div data-jsx={188072295}>
     <p data-jsx={188072295}>test</p>
     <p data-jsx={188072295}>woot</p>
-    <_JSXStyle styleId={188072295} css={\\"p[data-jsx=\\\\\\"188072295\\\\\\"]{color:red}\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsImZpbGUiOiJzb3VyY2UtbWFwcy5qcyIsInNvdXJjZXNDb250ZW50IjpbXX0= */\\\\n/*@ sourceURL=source-maps.js */\\"} />
+    <_JSXStyle styleId={188072295} css={\\"p[data-jsx=\\\\\\"188072295\\\\\\"]{color:red}\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFdBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"} />
   </div>);"
 `;
 


### PR DESCRIPTION
HMR is not working for me, the `__jsx-style-xxx` id is always one behind the one on the dom node, except for the initial load. Since it's out of sync the styling disappears on the target node. 
Steps to reproduce are simply to follow the instructions for setting up a new project and changing the something in the css. The changes are not reflected unless you refresh or 

Given this basic page:
```js
export default () =>
  <div>
    <h1 className="test">Hello</h1>
    <style jsx>{`
      .test {
        border: 3px blue solid;
      }
    `}</style>
  </div>;
```

Initially:
![image](https://user-images.githubusercontent.com/540683/26981543-ca8d0618-4d35-11e7-9498-c8ed55c180fd.png)

After an update to the css:
![image](https://user-images.githubusercontent.com/540683/26981666-2667171c-4d36-11e7-97bd-f0ca19463529.png)

I've been digging into this and found that [update() is called in componentWillUpdate()](https://github.com/zeit/styled-jsx/blob/master/src/style.js#L11-L13). Since the component's props are about to be updated [c.props.styleId](https://github.com/zeit/styled-jsx/blob/master/src/style.js#L27) refers to to the previous props. Thus the `styleId` gets out of sync and breaks HMR. If the lifecycle method is changed to `componentDidUpdate` this all works fine since the `this.props` (or `c.props`) are now the new ones. 

I'm not sure if there's a downside with this approach. I didn't see any issues with it but i might be missing something.

An alternative approach would be to pass in the `styleId` from the `nextProps` param to `componentWillUpdate`. I can update the PR to this if that makes more sense.

...Or maybe i'm just missing something obvious (_how is nobody else reporting this issue?.._)