### PR TITLE
Fix issue with undefined this.hub.file

### DIFF
--- a/src/babel-external.js
+++ b/src/babel-external.js
@@ -144,7 +144,8 @@ export const namedExportDeclarationVisitor = (path, opts) => {
 }
 
 export const moduleExportsVisitor = (path, opts) => {
-  if (path.get('left').getSource() !== 'module.exports') {
+  const left = path.get('left')
+  if (!left.hub || left.getSource() !== 'module.exports') {
     return
   }
   defaultExports(path, path.get('right'), opts)


### PR DESCRIPTION
Fixes zeit/next.js#2531.

Not totally satisfied with the fix, since it doesn't address what's causing `this.hub` to be undefined,  upstream in the build pipeline of Next.js.

In the issue discussion, another solution was suggested using MemberExpression instead of AssignmentExpression to check for `module.exports`, but I couldn't get one of the tests to pass.

This current pull request both solves the issue and passes all tests.