### PR TITLE
Fix hashes should match when using a single tag

### DIFF
--- a/src/_utils.js
+++ b/src/_utils.js
@@ -19,6 +19,8 @@ const or = (a, b) => t.logicalExpression('||', a, b)
 
 const joinSpreads = spreads => spreads.reduce((acc, curr) => or(acc, curr))
 
+export const hashString = str => String(_hashString(str))
+
 export const addClassName = (path, jsxId) => {
   const jsxIdWithSpace = concat(jsxId, t.stringLiteral(' '))
   const attributes = path.get('attributes')
@@ -74,8 +76,6 @@ export const addClassName = (path, jsxId) => {
     t.jSXAttribute(t.jSXIdentifier('className'), className)
   )
 }
-
-export const hashString = str => String(_hashString(str))
 
 export const getScope = path =>
   (path.findParent(
@@ -254,7 +254,7 @@ export const getJSXStyleInfo = (expr, scope) => {
 export const computeClassNames = (styles, externalJsxId) => {
   if (styles.length === 0) {
     return {
-      attribute: externalJsxId
+      className: externalJsxId
     }
   }
 
@@ -280,7 +280,7 @@ export const computeClassNames = (styles, externalJsxId) => {
   if (hashes.dynamic.length === 0) {
     return {
       staticClassName,
-      attribute: externalJsxId
+      className: externalJsxId
         ? concat(t.stringLiteral(staticClassName + ' '), externalJsxId)
         : t.stringLiteral(staticClassName)
     }
@@ -308,7 +308,7 @@ export const computeClassNames = (styles, externalJsxId) => {
   if (hashes.static.length === 0) {
     return {
       staticClassName,
-      attribute: externalJsxId
+      className: externalJsxId
         ? concat(concat(externalJsxId, t.stringLiteral(' ')), dynamic)
         : dynamic
     }
@@ -318,7 +318,7 @@ export const computeClassNames = (styles, externalJsxId) => {
   // '[jsx-externalClasses] jsx-staticClasses ' + _JSXStyle.dynamic([ ['5678', [props.foo, bar, fn(props)]], ... ])
   return {
     staticClassName,
-    attribute: externalJsxId
+    className: externalJsxId
       ? concat(
           concat(externalJsxId, t.stringLiteral(` ${staticClassName} `)),
           dynamic
@@ -440,7 +440,8 @@ export const processCss = (stylesInfo, options) => {
     isGlobal
   } = stylesInfo
 
-  const staticClassName = stylesInfo.staticClassName || `jsx-${hash}`
+  const staticClassName =
+    stylesInfo.staticClassName || `jsx-${hashString(hash)}`
 
   const { splitRules } = options
 
@@ -487,7 +488,7 @@ export const processCss = (stylesInfo, options) => {
   }
 
   return {
-    hash: dynamic ? hashString(hash + staticClassName) : hash,
+    hash: dynamic ? hashString(hash + staticClassName) : hashString(hash),
     css: transformedCss,
     expressions: dynamic && expressions
   }

--- a/src/babel.js
+++ b/src/babel.js
@@ -62,8 +62,8 @@ export default function({ types: t }) {
           name !== STYLE_COMPONENT &&
           name.charAt(0) !== name.charAt(0).toUpperCase()
         ) {
-          if (state.jsxId) {
-            addClassName(path, state.jsxId)
+          if (state.className) {
+            addClassName(path, state.className)
           }
         }
 
@@ -183,11 +183,11 @@ export default function({ types: t }) {
           }
 
           if (state.styles.length > 0 || externalJsxId) {
-            const { staticClassName, attribute } = computeClassNames(
+            const { staticClassName, className } = computeClassNames(
               state.styles,
               externalJsxId
             )
-            state.jsxId = attribute
+            state.className = className
             state.staticClassName = staticClassName
           }
 
@@ -200,7 +200,7 @@ export default function({ types: t }) {
 
           if (state.hasJSXStyle && !--state.ignoreClosing && !isGlobal) {
             state.hasJSXStyle = null
-            state.jsxId = null
+            state.className = null
             state.externalJsxId = null
           }
 

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -16,7 +16,7 @@ export const Test1 = () => <div className={\`jsx-\${styles.__scopedHash} jsx-\${
 // external and static
 export const Test2 = () => <div className={'jsx-2982525546 ' + \`jsx-\${styles.__scopedHash}\`}>
     <p className={'jsx-2982525546 ' + \`jsx-\${styles.__scopedHash}\`}>external and static</p>
-    <_JSXStyle styleId={\\"2648947580\\"} css={\\"p.jsx-2982525546{color:red}\\"} />
+    <_JSXStyle styleId={\\"2982525546\\"} css={\\"p.jsx-2982525546{color:red}\\"} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
   </div>;
 
@@ -30,7 +30,7 @@ export const Test3 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash
 // external, static and dynamic
 export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
     <p className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>external, static and dynamic</p>
-    <_JSXStyle styleId={\\"884414245\\"} css={\\"p.jsx-3190985107{display:inline-block}\\"} />
+    <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block}\\"} />
     <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color}}\`} dynamic={[color]} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
   </div>;
@@ -38,14 +38,14 @@ export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash
 // static only
 export const Test5 = () => <div className={\\"jsx-1372669040\\"}>
     <p className={\\"jsx-1372669040\\"}>static only</p>
-    <_JSXStyle styleId={\\"884414245\\"} css={\\"p.jsx-1372669040{display:inline-block}\\"} />
-    <_JSXStyle styleId={\\"2648947580\\"} css={\\"p.jsx-1372669040{color:red}\\"} />
+    <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-1372669040{display:inline-block}\\"} />
+    <_JSXStyle styleId={\\"2982525546\\"} css={\\"p.jsx-1372669040{color:red}\\"} />
   </div>;
 
 // static and dynamic
 export const Test6 = ({ color }) => <div className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
     <p className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>static and dynamic</p>
-    <_JSXStyle styleId={\\"884414245\\"} css={\\"p.jsx-3190985107{display:inline-block}\\"} />
+    <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block}\\"} />
     <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color}}\`} dynamic={[color]} />
   </div>;
 
@@ -90,6 +90,6 @@ export default (() => <div className={\\"jsx-2886504620\\"}>
     <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
     <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
     <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
-    <_JSXStyle styleId={\\"2947263116\\"} css={\\"div.jsx-2886504620{color:red}\\"} />
+    <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red}\\"} />
   </div>);"
 `;

--- a/test/__snapshots__/external.js.snap
+++ b/test/__snapshots__/external.js.snap
@@ -2,9 +2,9 @@
 
 exports[`(optimized) transpiles external stylesheets (CommonJS modules) 1`] = `
 "const _defaultExport = ['div{font-size:3em;}'];
-_defaultExport.__hash = '7060342740';
-_defaultExport.__scoped = ['div.jsx-7060342741{font-size:3em;}'];
-_defaultExport.__scopedHash = '7060342741';
+_defaultExport.__hash = '761548770';
+_defaultExport.__scoped = ['div.jsx-3720287939{font-size:3em;}'];
+_defaultExport.__scopedHash = '3720287939';
 
 
 module.exports = _defaultExport;"
@@ -16,29 +16,29 @@ exports[`(optimized) transpiles external stylesheets 1`] = `
 const color = 'red';
 
 const bar = ['div{font-size:3em;}'];
-bar.__hash = '7060342740';
-bar.__scoped = ['div.jsx-7060342741{font-size:3em;}'];
-bar.__scopedHash = '7060342741';
+bar.__hash = '761548770';
+bar.__scoped = ['div.jsx-3720287939{font-size:3em;}'];
+bar.__scopedHash = '3720287939';
 export const uh = bar;
 
 export const foo = [\`div{color:\${color};}\`];
 
-foo.__hash = '31421784000';
-foo.__scoped = [\`div.jsx-31421784001{color:\${color};}\`];
-foo.__scopedHash = '31421784001';
+foo.__hash = '3319550427';
+foo.__scoped = [\`div.jsx-3980805466{color:\${color};}\`];
+foo.__scopedHash = '3980805466';
 const _defaultExport = ['div{font-size:3em;}', \`p{color:\${color};}\`];
-_defaultExport.__hash = '40416528930';
-_defaultExport.__scoped = ['div.jsx-40416528931{font-size:3em;}', \`p.jsx-40416528931{color:\${color};}\`];
-_defaultExport.__scopedHash = '40416528931';
+_defaultExport.__hash = '392586103';
+_defaultExport.__scoped = ['div.jsx-311488054{font-size:3em;}', \`p.jsx-311488054{color:\${color};}\`];
+_defaultExport.__scopedHash = '311488054';
 export default _defaultExport;"
 `;
 
 exports[`transpiles external stylesheets (CommonJS modules) 1`] = `
 "const _defaultExport = new String('div{font-size:3em}');
 
-_defaultExport.__hash = '7060342740';
-_defaultExport.__scoped = 'div.jsx-7060342741{font-size:3em}';
-_defaultExport.__scopedHash = '7060342741';
+_defaultExport.__hash = '761548770';
+_defaultExport.__scoped = 'div.jsx-3720287939{font-size:3em}';
+_defaultExport.__scopedHash = '3720287939';
 
 
 module.exports = _defaultExport;"
@@ -50,22 +50,22 @@ exports[`transpiles external stylesheets 1`] = `
 const color = 'red';
 
 const bar = new String('div{font-size:3em}');
-bar.__hash = '7060342740';
-bar.__scoped = 'div.jsx-7060342741{font-size:3em}';
-bar.__scopedHash = '7060342741';
+bar.__hash = '761548770';
+bar.__scoped = 'div.jsx-3720287939{font-size:3em}';
+bar.__scopedHash = '3720287939';
 export const uh = bar;
 
 export const foo = new String(\`div{color:\${color}}\`);
 
-foo.__hash = '31421784000';
-foo.__scoped = \`div.jsx-31421784001{color:\${color}}\`;
-foo.__scopedHash = '31421784001';
+foo.__hash = '3319550427';
+foo.__scoped = \`div.jsx-3980805466{color:\${color}}\`;
+foo.__scopedHash = '3980805466';
 
 const _defaultExport = new String(\`div{font-size:3em}p{color:\${color}}\`);
 
-_defaultExport.__hash = '40416528930';
-_defaultExport.__scoped = \`div.jsx-40416528931{font-size:3em}p.jsx-40416528931{color:\${color}}\`;
-_defaultExport.__scopedHash = '40416528931';
+_defaultExport.__hash = '392586103';
+_defaultExport.__scoped = \`div.jsx-311488054{font-size:3em}p.jsx-311488054{color:\${color}}\`;
+_defaultExport.__scopedHash = '311488054';
 export default _defaultExport;"
 `;
 

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`generates source maps 1`] = `
 export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"188072295\\"} css={\\"p.jsx-2743241663{color:red}\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFVBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red}\\\\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFVBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"} />
   </div>);"
 `;
 
@@ -22,18 +22,18 @@ export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"188072295\\"} css={\\"p.jsx-2743241663{color:red}\\"} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red}\\"} />
   </div>);"
 `;
 
 exports[`mixed global and scoped 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
-const Test = () => <_JSXStyle styleId={\\"188072295\\"} css={\\"p{color:red}\\"} />;
+const Test = () => <_JSXStyle styleId={\\"2743241663\\"} css={\\"p{color:red}\\"} />;
 
 export default (() => <div className={\\"jsx-2673076688\\"}>
     <p className={\\"jsx-2673076688\\"}>test</p>
-    <_JSXStyle styleId={\\"3149549172\\"} css={\\"body{background:red}\\"} />
-    <_JSXStyle styleId={\\"188072295\\"} css={\\"p.jsx-2673076688{color:red}\\"} />
+    <_JSXStyle styleId={\\"4269072806\\"} css={\\"body{background:red}\\"} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2673076688{color:red}\\"} />
   </div>);"
 `;
 
@@ -44,12 +44,12 @@ const otherColor = 'green';
 
 const A = () => <div className={\\"jsx-57381496\\"}>
     <p className={\\"jsx-57381496\\"}>test</p>
-    <_JSXStyle styleId={\\"924167211\\"} css={\`p.jsx-57381496{color:\${color}}\`} />
+    <_JSXStyle styleId={\\"57381496\\"} css={\`p.jsx-57381496{color:\${color}}\`} />
   </div>;
 
 const B = () => <div className={\\"jsx-3099245642\\"}>
     <p className={\\"jsx-3099245642\\"}>test</p>
-    <_JSXStyle styleId={\\"45234319\\"} css={\`p.jsx-3099245642{color:\${otherColor}}\`} />
+    <_JSXStyle styleId={\\"3099245642\\"} css={\`p.jsx-3099245642{color:\${otherColor}}\`} />
   </div>;
 
 export default (() => <div>
@@ -63,7 +63,7 @@ exports[`should not add the data-jsx attribute to components instances 1`] = `
 const Test = () => <div className={\\"jsx-2529315885\\"}>
     <span className={\\"jsx-2529315885\\"}>test</span>
     <Component />
-    <_JSXStyle styleId={\\"1535297024\\"} css={\\"span.jsx-2529315885{color:red}\\"} />
+    <_JSXStyle styleId={\\"2529315885\\"} css={\\"span.jsx-2529315885{color:red}\\"} />
   </div>;"
 `;
 
@@ -74,7 +74,7 @@ export default class {
   render() {
     return <div className={\\"jsx-2101845350\\"}>
         <p className={\\"jsx-2101845350\\"}>test</p>
-        <_JSXStyle styleId={\\"1891769468\\"} css={\\"p.jsx-2101845350{color:red}\\"} />
+        <_JSXStyle styleId={\\"2101845350\\"} css={\\"p.jsx-2101845350{color:red}\\"} />
       </div>;
   }
 
@@ -93,17 +93,17 @@ const obj = { display: 'block' };
 
 export default (({ display }) => <div className={'jsx-3922596756 ' + _JSXStyle.dynamic([['1795062918', [display ? 'block' : 'none']]])}>
     <p className={'jsx-3922596756 ' + _JSXStyle.dynamic([['1795062918', [display ? 'block' : 'none']]])}>test</p>
-    <_JSXStyle styleId={\\"3864570373\\"} css={\`p.\${color}.jsx-3922596756{color:\${otherColor};display:\${obj.display}}\`} />
-    <_JSXStyle styleId={\\"188072295\\"} css={\\"p.jsx-3922596756{color:red}\\"} />
-    <_JSXStyle styleId={\\"964903971\\"} css={\`body{background:\${color}}\`} />
-    <_JSXStyle styleId={\\"964903971\\"} css={\`body{background:\${color}}\`} />
-    <_JSXStyle styleId={\\"2993630608\\"} css={\`p.jsx-3922596756{color:\${color}}\`} />
-    <_JSXStyle styleId={\\"2993630608\\"} css={\`p.jsx-3922596756{color:\${color}}\`} />
-    <_JSXStyle styleId={\\"2683050534\\"} css={\`p.jsx-3922596756{color:\${darken(color)}}\`} />
-    <_JSXStyle styleId={\\"1376588607\\"} css={\`p.jsx-3922596756{color:\${darken(color) + 2}}\`} />
-    <_JSXStyle styleId={\\"3617592140\\"} css={\`@media (min-width:\${mediumScreen}){p.jsx-3922596756{color:green}p.jsx-3922596756{color:\${\`red\`}}}p.jsx-3922596756{color:red}\`} />
-    <_JSXStyle styleId={\\"4197553757\\"} css={\`p.jsx-3922596756{-webkit-animation-duration:\${animationDuration};animation-duration:\${animationDuration}}\`} />
-    <_JSXStyle styleId={\\"1220291314\\"} css={\`p.jsx-3922596756{-webkit-animation:\${animationDuration} forwards \${animationName};animation:\${animationDuration} forwards \${animationName}}div.jsx-3922596756{background:\${color}}\`} />
+    <_JSXStyle styleId={\\"1003380713\\"} css={\`p.\${color}.jsx-3922596756{color:\${otherColor};display:\${obj.display}}\`} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-3922596756{color:red}\\"} />
+    <_JSXStyle styleId={\\"602592955\\"} css={\`body{background:\${color}}\`} />
+    <_JSXStyle styleId={\\"602592955\\"} css={\`body{background:\${color}}\`} />
+    <_JSXStyle styleId={\\"128557999\\"} css={\`p.jsx-3922596756{color:\${color}}\`} />
+    <_JSXStyle styleId={\\"128557999\\"} css={\`p.jsx-3922596756{color:\${color}}\`} />
+    <_JSXStyle styleId={\\"2622100973\\"} css={\`p.jsx-3922596756{color:\${darken(color)}}\`} />
+    <_JSXStyle styleId={\\"1167419394\\"} css={\`p.jsx-3922596756{color:\${darken(color) + 2}}\`} />
+    <_JSXStyle styleId={\\"4052509549\\"} css={\`@media (min-width:\${mediumScreen}){p.jsx-3922596756{color:green}p.jsx-3922596756{color:\${\`red\`}}}p.jsx-3922596756{color:red}\`} />
+    <_JSXStyle styleId={\\"2824547816\\"} css={\`p.jsx-3922596756{-webkit-animation-duration:\${animationDuration};animation-duration:\${animationDuration}}\`} />
+    <_JSXStyle styleId={\\"417951176\\"} css={\`p.jsx-3922596756{-webkit-animation:\${animationDuration} forwards \${animationName};animation:\${animationDuration} forwards \${animationName}}div.jsx-3922596756{background:\${color}}\`} />
 
     <_JSXStyle styleId={\\"1795062918\\"} css={\`span.__jsx-style-dynamic-selector{display:\${display ? 'block' : 'none'}}\`} dynamic={[display ? 'block' : 'none']} />
   </div>);"
@@ -156,10 +156,10 @@ export default (() => <div className={'jsx-2534288328 ' + \`jsx-\${styles3.__sco
 exports[`works with global styles 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 const Test = () => <div className={\\"jsx-2209073070\\"}>
-    <_JSXStyle styleId={\\"3477488769\\"} css={\\"body{color:red}:hover{color:red;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-animation:foo 1s ease-out;animation:foo 1s ease-out}div a{display:none}[data-test]>div{color:red}\\"} />
+    <_JSXStyle styleId={\\"2209073070\\"} css={\\"body{color:red}:hover{color:red;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-animation:foo 1s ease-out;animation:foo 1s ease-out}div a{display:none}[data-test]>div{color:red}\\"} />
   </div>;
 
-const Test2 = () => <_JSXStyle styleId={\\"188072295\\"} css={\\"p{color:red}\\"} />;"
+const Test2 = () => <_JSXStyle styleId={\\"2743241663\\"} css={\\"p{color:red}\\"} />;"
 `;
 
 exports[`works with multiple jsx blocks 1`] = `
@@ -171,21 +171,21 @@ const attrs = {
 const Test1 = () => <div className={\\"jsx-2529315885\\"}>
     <span {...attrs} data-test=\\"test\\" className={\\"jsx-2529315885\\" + \\" \\" + (attrs.className != null && attrs.className || \\"\\")}>test</span>
     <Component />
-    <_JSXStyle styleId={\\"1535297024\\"} css={\\"span.jsx-2529315885{color:red}\\"} />
+    <_JSXStyle styleId={\\"2529315885\\"} css={\\"span.jsx-2529315885{color:red}\\"} />
   </div>;
 
 const Test2 = () => <span>test</span>;
 
 const Test3 = () => <div className={\\"jsx-2529315885\\"}>
     <span className={\\"jsx-2529315885\\"}>test</span>
-    <_JSXStyle styleId={\\"1535297024\\"} css={\\"span.jsx-2529315885{color:red}\\"} />
+    <_JSXStyle styleId={\\"2529315885\\"} css={\\"span.jsx-2529315885{color:red}\\"} />
   </div>;
 
 export default class {
   render() {
     return <div className={\\"jsx-2101845350\\"}>
         <p className={\\"jsx-2101845350\\"}>test</p>
-        <_JSXStyle styleId={\\"1891769468\\"} css={\\"p.jsx-2101845350{color:red}\\"} />
+        <_JSXStyle styleId={\\"2101845350\\"} css={\\"p.jsx-2101845350{color:red}\\"} />
       </div>;
   }
 }"
@@ -196,7 +196,7 @@ exports[`works with non styled-jsx styles 1`] = `
 export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>woot</p>
     <style dangerouslySetInnerHTML={{ __html: \`body { margin: 0; }\` }}></style>
-    <_JSXStyle styleId={\\"188072295\\"} css={\\"p.jsx-2743241663{color:red}\\"} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red}\\"} />
   </div>);"
 `;
 
@@ -206,6 +206,6 @@ export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"188072295\\"} css={\\"p.jsx-2743241663{color:red}\\"} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red}\\"} />
   </div>);"
 `;


### PR DESCRIPTION
When there is **only a single** `style` tag per component we still `hashString` its hash (since we always do `hashString(hashes)` where `hashes` is an array). The resulting hash is used to scope CSS. 

However the `styleId` for `JSXStyle` then used just `hashes[0]` resulting in something like this:

```jsx
<_JSXStyle styleId="1234" css="div.jsx-9887 { color: red }" />
```

Instead with this fix it will match:


```jsx
<_JSXStyle styleId="9887" css="div.jsx-9887 { color: red }" />
```

Again, this was an issue only when there was a single `style` tag per component. When there are multiple it is normal that `styleId` and the hash in the css don't match