### PR TITLE
Fix broken template literal for external className

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -168,12 +168,12 @@ export default function({ types: t }) {
               externalJsxId = null
             } else {
               // Construct a template literal of this form:
-              // `${styles.__scopedHash} ${otherStyles.__scopedHash}`
+              // `jsx-${styles.__scopedHash} jsx-${otherStyles.__scopedHash}`
               externalJsxId = t.templateLiteral(
                 [
-                  t.templateElement({ raw: 'jsx-', cooked: '' }),
+                  t.templateElement({ raw: 'jsx-', cooked: 'jsx-' }),
                   ...[...new Array(expressionsLength - 1)].map(() =>
-                    t.templateElement({ raw: ' jsx-', cooked: ' ' })
+                    t.templateElement({ raw: ' jsx-', cooked: ' jsx-' })
                   ),
                   t.templateElement({ raw: '', cooked: '' }, true)
                 ],

--- a/test/__snapshots__/external.js.snap
+++ b/test/__snapshots__/external.js.snap
@@ -101,13 +101,21 @@ import styles from './styles';
 const styles2 = require('./styles2');
 import { foo as styles3 } from './styles';
 
-export default (() => <div className={'jsx-2534288328 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`} data-jsx>
-    <p className={'jsx-2534288328 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`} data-jsx>test</p>
-    <p className={'jsx-2534288328 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`} data-jsx>woot</p>
+export default (() => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`}>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\` + ' ' + 'foo'}>test</p>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`}>woot</p>
     <_JSXStyle styleId={styles2.__hash} css={styles2} />
     <_JSXStyle styleId={styles3.__scopedHash} css={styles3.__scoped} />
-    <div className={'jsx-2534288328 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`} data-jsx>woot</div>
-    <_JSXStyle styleId={\\"1144769207\\"} css={\\"p.jsx-2534288328{color:red}div.jsx-2534288328{color:green}\\"} />
+    <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`}>woot</div>
+    <_JSXStyle styleId={\\"1646697228\\"} css={\\"p.jsx-1646697228{color:red}div.jsx-1646697228{color:green}\\"} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
-  </div>);"
+  </div>);
+
+export const Test = () => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\`}>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\` + ' ' + 'foo'}>test</p>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\`}>woot</p>
+    <_JSXStyle styleId={styles3.__scopedHash} css={styles3.__scoped} />
+    <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\`}>woot</div>
+    <_JSXStyle styleId={\\"1646697228\\"} css={\\"p.jsx-1646697228{color:red}div.jsx-1646697228{color:green}\\"} />
+  </div>;"
 `;

--- a/test/external.js
+++ b/test/external.js
@@ -35,23 +35,22 @@ test('(optimized) transpiles external stylesheets (CommonJS modules)', async t =
 })
 
 test('throws when using `this.something` in external stylesheets', async t => {
-  const { message } = await t.throws(
-    transform('./fixtures/styles-external-invalid.js')
-  )
+  const { message } = await t.throws(transform('./fixtures/styles-external-invalid.js'))
   t.regex(message, /this\.props/)
 })
 
 test('throws when referring an undefined value in external stylesheets', async t => {
-  const { message } = await t.throws(
-    transform('./fixtures/styles-external-invalid2.js')
-  )
+  const { message } = await t.throws(transform('./fixtures/styles-external-invalid2.js'))
   t.regex(message, /props\.color/)
 })
 
+test('use external stylesheets', async t => {
+  const { code } = await transform('./fixtures/external-stylesheet.js')
+  t.snapshot(code)
+})
+
 test('use external stylesheets (multi-line)', async t => {
-  const { code } = await transform(
-    './fixtures/external-stylesheet-multi-line.js'
-  )
+  const { code } = await transform('./fixtures/external-stylesheet-multi-line.js')
   t.snapshot(code)
 })
 

--- a/test/fixtures/external-stylesheet.js
+++ b/test/fixtures/external-stylesheet.js
@@ -4,15 +4,38 @@ import { foo as styles3 } from './styles'
 
 export default () => (
   <div>
-    <p>test</p>
+    <p className="foo">test</p>
     <p>woot</p>
-    <style jsx global>{styles2}</style>
+    <style jsx global>
+      {styles2}
+    </style>
     <style jsx>{styles3}</style>
     <div>woot</div>
     <style jsx>{`
-      p { color: red }
-      div { color: green; }
+      p {
+        color: red;
+      }
+      div {
+        color: green;
+      }
     `}</style>
     <style jsx>{styles}</style>
+  </div>
+)
+
+export const Test = () => (
+  <div>
+    <p className="foo">test</p>
+    <p>woot</p>
+    <style jsx>{styles3}</style>
+    <div>woot</div>
+    <style jsx>{`
+      p {
+        color: red;
+      }
+      div {
+        color: green;
+      }
+    `}</style>
   </div>
 )


### PR DESCRIPTION
Fixes #300

when generating the `className` attribute for external styles the template literal had only the `raw` value and was missing the `cooked` one.