### PR TITLE
Stylus Plugin Link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -527,6 +527,7 @@ The following plugins are proof of concepts/sample:
 * [styled-jsx-plugin-postcss](https://github.com/giuseppeg/styled-jsx-plugin-postcss)
 * [styled-jsx-plugin-stylelint](https://github.com/giuseppeg/styled-jsx-plugin-stylelint)
 * [styled-jsx-plugin-less](https://github.com/erasmo-marin/styled-jsx-plugin-less)
+* [styled-jsx-plugin-stylus](https://github.com/omardelarosa/styled-jsx-plugin-stylus)
 
 ## Syntax Highlighting
 


### PR DESCRIPTION
Hello,

I recently made a plugin to support the use of [stylus](http://stylus-lang.com/) in styled-jsx blocks.

This PR adds a link to the Readme file to the plugin `styled-jsx-plugin-stylus`:

https://github.com/omardelarosa/styled-jsx-plugin-stylus