### PR TITLE
Add dummy styled-jsx/css.js module

### DIFF
--- a/css.js
+++ b/css.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  throw new Error(
+    'styled-jsx/css: if you are getting this error it means that your `css` tagged template literals were not transpiled.'
+  )
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lib",
     "server.js",
     "babel.js",
-    "style.js"
+    "style.js",
+    "css.js"
   ],
   "babel": {
     "presets": [


### PR DESCRIPTION
Fixes #347

Also prevents errors when bundlers like webpack resolve dependencies of packages that do have `import css from 'styled-jsx/css'`.