### PR TITLE
Properly expose filename to plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -553,7 +553,6 @@ The `options` object has the following shape:
     vendorPrefixes: boolean,
     isGlobal: boolean,
     filename: ?string, // defined only when styled-jsx/babel is used via Babel CLI,
-    sourceFileName: string, // the original Javascript file the CSS block was in
     location: { // the original location of the CSS block in the JavaScript file
       start: {
         line: number,

--- a/readme.md
+++ b/readme.md
@@ -553,6 +553,7 @@ The `options` object has the following shape:
     vendorPrefixes: boolean,
     isGlobal: boolean,
     filename: ?string, // defined only when styled-jsx/babel is used via Babel CLI,
+    sourceFileName: string, // the original Javascript file the CSS block was in
     location: { // the original location of the CSS block in the JavaScript file
       start: {
         line: number,

--- a/readme.md
+++ b/readme.md
@@ -552,7 +552,7 @@ The `options` object has the following shape:
     sourceMaps: boolean,
     vendorPrefixes: boolean,
     isGlobal: boolean,
-    filename: ?string, // defined only when styled-jsx/babel is used via Babel CLI,
+    filename: ?string, // defined only when the filename option is passed to Babel, such as when using Babel CLI or Webpack
     location: { // the original location of the CSS block in the JavaScript file
       start: {
         line: number,

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -524,7 +524,8 @@ export const processCss = (stylesInfo, options) => {
     vendorPrefixes,
     sourceMaps: useSourceMaps,
     isGlobal,
-    filename: fileInfo.filename
+    filename: fileInfo.filename,
+    sourceFileName: fileInfo.sourceFileName
   }
 
   let transformedCss

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -524,8 +524,7 @@ export const processCss = (stylesInfo, options) => {
     vendorPrefixes,
     sourceMaps: useSourceMaps,
     isGlobal,
-    filename: fileInfo.filename,
-    sourceFileName: fileInfo.sourceFileName
+    filename: fileInfo.filename
   }
 
   let transformedCss

--- a/src/babel.js
+++ b/src/babel.js
@@ -238,7 +238,7 @@ export default function({ types: t }) {
               file: state.file,
               sourceFileName: state.file.opts.sourceFileName,
               sourceMaps,
-              filename: state.file.filename
+              filename: state.file.opts.filename
             },
             staticClassName: state.staticClassName,
             isGlobal,

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -21,17 +21,17 @@ export const Test2 = () => <div className={'jsx-2982525546 ' + \`jsx-\${styles._
   </div>;
 
 // external and dynamic
-export const Test3 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>
-    <p className={\`jsx-\${styles.__scopedHash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>external and dynamic</p>
-    <_JSXStyle styleId={\\"1947484460\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+export const Test3 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' ' + _JSXStyle.dynamic([['506814403', [color]]])}>
+    <p className={\`jsx-\${styles.__scopedHash}\` + ' ' + _JSXStyle.dynamic([['506814403', [color]]])}>external and dynamic</p>
+    <_JSXStyle styleId={\\"506814403\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
   </div>;
 
 // external, static and dynamic
-export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
-    <p className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>external, static and dynamic</p>
+export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1968494501', [color]]])}>
+    <p className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1968494501', [color]]])}>external, static and dynamic</p>
     <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block;}\\"} />
-    <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+    <_JSXStyle styleId={\\"1968494501\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
   </div>;
 
@@ -43,16 +43,16 @@ export const Test5 = () => <div className={\\"jsx-1372669040\\"}>
   </div>;
 
 // static and dynamic
-export const Test6 = ({ color }) => <div className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
-    <p className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>static and dynamic</p>
+export const Test6 = ({ color }) => <div className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1968494501', [color]]])}>
+    <p className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1968494501', [color]]])}>static and dynamic</p>
     <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block;}\\"} />
-    <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+    <_JSXStyle styleId={\\"1968494501\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
   </div>;
 
 // dynamic only
-export const Test7 = ({ color }) => <div className={_JSXStyle.dynamic([['1947484460', [color]]])}>
-    <p className={_JSXStyle.dynamic([['1947484460', [color]]])}>dynamic only</p>
-    <_JSXStyle styleId={\\"1947484460\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+export const Test7 = ({ color }) => <div className={_JSXStyle.dynamic([['506814403', [color]]])}>
+    <p className={_JSXStyle.dynamic([['506814403', [color]]])}>dynamic only</p>
+    <_JSXStyle styleId={\\"506814403\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
   </div>;"
 `;
 

--- a/test/__snapshots__/external.js.snap
+++ b/test/__snapshots__/external.js.snap
@@ -22,14 +22,14 @@ bar.__scoped = ['div.jsx-546996693{font-size:3em;}'];
 bar.__scopedHash = '546996693';
 const a = [\`div{font-size:\${size}em;}\`];
 
-a.__hash = '1282571833';
-a.__scoped = [\`div.jsx-2741963512{font-size:\${size}em;}\`];
-a.__scopedHash = '2741963512';
+a.__hash = '1918380945';
+a.__scoped = [\`div.jsx-759117712{font-size:\${size}em;}\`];
+a.__scopedHash = '759117712';
 const b = [\`div{color:\${colors.green.light};}\`];
 
-b.__hash = '3466620163';
-b.__scoped = [\`div.jsx-3071343650{color:\${colors.green.light};}\`];
-b.__scopedHash = '3071343650';
+b.__hash = '758388080';
+b.__scoped = [\`div.jsx-2144106801{color:\${colors.green.light};}\`];
+b.__scopedHash = '2144106801';
 export const uh = bar;
 
 export const foo = [\`div{color:\${color};}\`];
@@ -38,9 +38,9 @@ foo.__hash = '3319550427';
 foo.__scoped = [\`div.jsx-3980805466{color:\${color};}\`];
 foo.__scopedHash = '3980805466';
 const _defaultExport = ['div{font-size:3em;}', \`p{color:\${color};}\`];
-_defaultExport.__hash = '14787253';
-_defaultExport.__scoped = ['div.jsx-602449652{font-size:3em;}', \`p.jsx-602449652{color:\${color};}\`];
-_defaultExport.__scopedHash = '602449652';
+_defaultExport.__hash = '39513534';
+_defaultExport.__scoped = ['div.jsx-1836411391{font-size:3em;}', \`p.jsx-1836411391{color:\${color};}\`];
+_defaultExport.__scopedHash = '1836411391';
 export default _defaultExport;"
 `;
 
@@ -100,14 +100,14 @@ bar.__scoped = 'div.jsx-546996693{font-size:3em;}';
 bar.__scopedHash = '546996693';
 const a = new String(\`div{font-size:\${size}em;}\`);
 
-a.__hash = '1282571833';
-a.__scoped = \`div.jsx-2741963512{font-size:\${size}em;}\`;
-a.__scopedHash = '2741963512';
+a.__hash = '1918380945';
+a.__scoped = \`div.jsx-759117712{font-size:\${size}em;}\`;
+a.__scopedHash = '759117712';
 const b = new String(\`div{color:\${colors.green.light};}\`);
 
-b.__hash = '3466620163';
-b.__scoped = \`div.jsx-3071343650{color:\${colors.green.light};}\`;
-b.__scopedHash = '3071343650';
+b.__hash = '758388080';
+b.__scoped = \`div.jsx-2144106801{color:\${colors.green.light};}\`;
+b.__scopedHash = '2144106801';
 export const uh = bar;
 
 export const foo = new String(\`div{color:\${color};}\`);
@@ -118,9 +118,9 @@ foo.__scopedHash = '3980805466';
 
 const _defaultExport = new String(\`div{font-size:3em;}p{color:\${color};}\`);
 
-_defaultExport.__hash = '14787253';
-_defaultExport.__scoped = \`div.jsx-602449652{font-size:3em;}p.jsx-602449652{color:\${color};}\`;
-_defaultExport.__scopedHash = '602449652';
+_defaultExport.__hash = '39513534';
+_defaultExport.__scoped = \`div.jsx-1836411391{font-size:3em;}p.jsx-1836411391{color:\${color};}\`;
+_defaultExport.__scopedHash = '1836411391';
 export default _defaultExport;"
 `;
 

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`generates source maps 1`] = `
 export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFVBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFVBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXHJcbiAgPGRpdj5cclxuICAgIDxwPnRlc3Q8L3A+XHJcbiAgICA8cD53b290PC9wPlxyXG4gICAgPHN0eWxlIGpzeD57J3AgeyBjb2xvcjogcmVkIH0nfTwvc3R5bGU+XHJcbiAgPC9kaXY+XHJcbilcclxuIl19 */\\\\n/*@ sourceURL=source-maps.js */\\"} />
   </div>);"
 `;
 
@@ -115,21 +115,21 @@ const animationDuration = '200ms';
 const animationName = 'my-cool-animation';
 const obj = { display: 'block' };
 
-export default (({ display }) => <div className={'jsx-3922596756 ' + _JSXStyle.dynamic([['1795062918', [display ? 'block' : 'none']]])}>
-    <p className={'jsx-3922596756 ' + _JSXStyle.dynamic([['1795062918', [display ? 'block' : 'none']]])}>test</p>
-    <_JSXStyle styleId={\\"1003380713\\"} css={\`p.\${color}.jsx-3922596756{color:\${otherColor};display:\${obj.display};}\`} />
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-3922596756{color:red;}\\"} />
-    <_JSXStyle styleId={\\"602592955\\"} css={\`body{background:\${color};}\`} />
-    <_JSXStyle styleId={\\"602592955\\"} css={\`body{background:\${color};}\`} />
-    <_JSXStyle styleId={\\"128557999\\"} css={\`p.jsx-3922596756{color:\${color};}\`} />
-    <_JSXStyle styleId={\\"128557999\\"} css={\`p.jsx-3922596756{color:\${color};}\`} />
-    <_JSXStyle styleId={\\"2622100973\\"} css={\`p.jsx-3922596756{color:\${darken(color)};}\`} />
-    <_JSXStyle styleId={\\"1167419394\\"} css={\`p.jsx-3922596756{color:\${darken(color) + 2};}\`} />
-    <_JSXStyle styleId={\\"4052509549\\"} css={\`@media (min-width:\${mediumScreen}){p.jsx-3922596756{color:green;}p.jsx-3922596756{color:\${\`red\`};}}p.jsx-3922596756{color:red;}\`} />
-    <_JSXStyle styleId={\\"2824547816\\"} css={\`p.jsx-3922596756{-webkit-animation-duration:\${animationDuration};animation-duration:\${animationDuration};}\`} />
-    <_JSXStyle styleId={\\"417951176\\"} css={\`p.jsx-3922596756{-webkit-animation:\${animationDuration} forwards \${animationName};animation:\${animationDuration} forwards \${animationName};}div.jsx-3922596756{background:\${color};}\`} />
+export default (({ display }) => <div className={'jsx-541574342 ' + _JSXStyle.dynamic([['978431106', [display ? 'block' : 'none']]])}>
+    <p className={'jsx-541574342 ' + _JSXStyle.dynamic([['978431106', [display ? 'block' : 'none']]])}>test</p>
+    <_JSXStyle styleId={\\"931263639\\"} css={\`p.\${color}.jsx-541574342{color:\${otherColor};display:\${obj.display};}\`} />
+    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-541574342{color:red;}\\"} />
+    <_JSXStyle styleId={\\"158791332\\"} css={\`body{background:\${color};}\`} />
+    <_JSXStyle styleId={\\"158791332\\"} css={\`body{background:\${color};}\`} />
+    <_JSXStyle styleId={\\"2756023168\\"} css={\`p.jsx-541574342{color:\${color};}\`} />
+    <_JSXStyle styleId={\\"2756023168\\"} css={\`p.jsx-541574342{color:\${color};}\`} />
+    <_JSXStyle styleId={\\"1040140238\\"} css={\`p.jsx-541574342{color:\${darken(color)};}\`} />
+    <_JSXStyle styleId={\\"462794058\\"} css={\`p.jsx-541574342{color:\${darken(color) + 2};}\`} />
+    <_JSXStyle styleId={\\"54541817\\"} css={\`@media (min-width:\${mediumScreen}){p.jsx-541574342{color:green;}p.jsx-541574342{color:\${\`red\`};}}p.jsx-541574342{color:red;}\`} />
+    <_JSXStyle styleId={\\"1972281407\\"} css={\`p.jsx-541574342{-webkit-animation-duration:\${animationDuration};animation-duration:\${animationDuration};}\`} />
+    <_JSXStyle styleId={\\"1722447948\\"} css={\`p.jsx-541574342{-webkit-animation:\${animationDuration} forwards \${animationName};animation:\${animationDuration} forwards \${animationName};}div.jsx-541574342{background:\${color};}\`} />
 
-    <_JSXStyle styleId={\\"1795062918\\"} css={\`span.__jsx-style-dynamic-selector{display:\${display ? 'block' : 'none'};}\`} dynamic={[display ? 'block' : 'none']} />
+    <_JSXStyle styleId={\\"978431106\\"} css={\`span.__jsx-style-dynamic-selector{display:\${display ? 'block' : 'none'};}\`} dynamic={[display ? 'block' : 'none']} />
   </div>);"
 `;
 

--- a/test/__snapshots__/plugins.js.snap
+++ b/test/__snapshots__/plugins.js.snap
@@ -5,9 +5,9 @@ exports[`applies plugins 1`] = `
 import styles from './styles';
 const color = 'red';
 
-export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>
-    <p className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>test</p>
-    <_JSXStyle styleId={\\"3382438999\\"} css={\`span.\${color}.jsx-3382438999{color:\${otherColor};}\`} />
+export default (() => <div className={'jsx-3611311908 ' + \`jsx-\${styles.__scopedHash}\`}>
+    <p className={'jsx-3611311908 ' + \`jsx-\${styles.__scopedHash}\`}>test</p>
+    <_JSXStyle styleId={\\"3611311908\\"} css={\`span.\${color}.jsx-3611311908{color:\${otherColor};}\`} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
   </div>);"
 `;
@@ -17,9 +17,9 @@ exports[`passes options to plugins 1`] = `
 import styles from './styles';
 const color = 'red';
 
-export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>
-    <p className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>test</p>
-    <_JSXStyle styleId={\\"3382438999\\"} css={\\".test.jsx-3382438999{content:\\\\\\"{\\\\\\"foo\\\\\\":false,\\\\\\"babel\\\\\\":{\\\\\\"location\\\\\\":{\\\\\\"start\\\\\\":{\\\\\\"line\\\\\\":7,\\\\\\"column\\\\\\":16},\\\\\\"end\\\\\\":{\\\\\\"line\\\\\\":11,\\\\\\"column\\\\\\":5}},\\\\\\"vendorPrefixes\\\\\\":false,\\\\\\"sourceMaps\\\\\\":false,\\\\\\"isGlobal\\\\\\":false}}\\\\\\";}\\"} />
+export default (() => <div className={'jsx-3611311908 ' + \`jsx-\${styles.__scopedHash}\`}>
+    <p className={'jsx-3611311908 ' + \`jsx-\${styles.__scopedHash}\`}>test</p>
+    <_JSXStyle styleId={\\"3611311908\\"} css={\\".test.jsx-3611311908{content:\\\\\\"{\\\\\\"foo\\\\\\":false,\\\\\\"babel\\\\\\":{\\\\\\"location\\\\\\":{\\\\\\"start\\\\\\":{\\\\\\"line\\\\\\":7,\\\\\\"column\\\\\\":16},\\\\\\"end\\\\\\":{\\\\\\"line\\\\\\":11,\\\\\\"column\\\\\\":5}},\\\\\\"vendorPrefixes\\\\\\":false,\\\\\\"sourceMaps\\\\\\":false,\\\\\\"isGlobal\\\\\\":false,\\\\\\"filename\\\\\\":\\\\\\"C:/Users/mporc/common/projects/styled-jsx/test/fixtures/with-plugins.js\\\\\\"}}\\\\\\";}\\"} />
     <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
   </div>);"
 `;


### PR DESCRIPTION
I'm trying to add relative imports to the styled jsx plugin `styled-jsx-plugin-sass`, but to do that, I need to be able to give sass the directory containing the file (that contains the CSS chunk).

You can read more of the discussion here: https://github.com/giuseppeg/styled-jsx-plugin-sass/issues/10

I imagine other plugins could have their uses for this too, if anything is wrong feedback is appreciated!

I noticed when I was testing this via nextjs that `fileInfo.sourceFileName` can have a query attached to it eg `./pages/index.js?entry` and I wasn't sure whether to strip the query or leave that to the plugin author, in this PR I just left it.

Thanks!

(EDIT: oh no snapshot testing I don't know how to deal with it!)