### PR TITLE
Fix null characters break Stylis compilation

### DIFF
--- a/src/lib/style-transform.js
+++ b/src/lib/style-transform.js
@@ -6,12 +6,9 @@ const stylis = new Stylis()
 function disableNestingPlugin(...args) {
   let [context, , , parent = [], line, column] = args
   if (context === 2) {
-    parent = parent[0]
-    if (
-      typeof parent === 'string' &&
-      parent.trim().length > 0 &&
-      parent.charAt(0) !== '@'
-    ) {
+    // replace null characters and trim
+    parent = (parent[0] || '').replace(/\u0000/g, '').trim()
+    if (parent.length > 0 && parent.charAt(0) !== '@') {
       throw new Error(
         `Nesting detected at ${line}:${column}. ` +
           'Unfortunately nesting is not supported by styled-jsx.'
@@ -101,7 +98,9 @@ function transform(hash, styles, settings = {}) {
 
   stylis.set({
     prefix:
-      typeof settings.vendorPrefixes === 'boolean' ? settings.vendorPrefixes : true
+      typeof settings.vendorPrefixes === 'boolean'
+        ? settings.vendorPrefixes
+        : true
   })
 
   stylis(hash, styles)

--- a/test/styles.js
+++ b/test/styles.js
@@ -58,6 +58,20 @@ test("doesn't throw when using at-rules", t => {
       0% { opacity: 0 }
       100% { opacity: 1}
     }
+    `,
+    // Line with one space before @rule
+    `div { color: red; }
+ 
+     @media screen and (min-width: 480px) {
+       div { color: red; }
+     }
+     `,
+    // Line with one tab before @rule
+    `div { color: red; }
+	
+     @media screen and (min-width: 480px) {
+       div { color: red; }
+     }
     `
   ]
 


### PR DESCRIPTION
Fixes #366

Some editor insert NULL characters `\u0000`. Not sure why, but this PR should fix this.