### PR TITLE
Sanitize dynamic styles

### DIFF
--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -153,10 +153,10 @@ export default class StyleSheetRegistry {
   ) {
     const cache = {}
     return function(id, css) {
-      // Sanitize SSR-ed and client side (style tags) CSS.
-      // When using optimize for speed we don't need to sanitize
-      // because we are not inserting markup in the DOM.
-      if (!this._isBrowser || !this._optimizeForSpeed) {
+      // Sanitize SSR-ed CSS.
+      // Client side code doesn't need to be sanitized since we use
+      // document.createTextNode (dev) and the CSSOM api sheet.insertRule (prod).
+      if (!this._isBrowser) {
         css = sanitize(css)
       }
       const idcss = id + css

--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -1,6 +1,7 @@
 import hashString from 'string-hash'
 import DefaultStyleSheet from './lib/stylesheet'
 
+const sanitize = rule => rule.replace(/\/style/g, '\\/style')
 export default class StyleSheetRegistry {
   constructor({
     styleSheet = null,
@@ -13,7 +14,13 @@ export default class StyleSheetRegistry {
         name: 'styled-jsx',
         optimizeForSpeed
       })
+
     this._sheet.inject()
+    if (styleSheet && typeof optimizeForSpeed === 'boolean') {
+      this._sheet.setOptimizeForSpeed(optimizeForSpeed)
+      this._optimizeForSpeed = this._sheet.isOptimizeForSpeed()
+    }
+
     this._isBrowser = isBrowser
 
     this._fromServer = undefined
@@ -146,6 +153,12 @@ export default class StyleSheetRegistry {
   ) {
     const cache = {}
     return function(id, css) {
+      // Sanitize SSR-ed and client side (style tags) CSS.
+      // When using optimize for speed we don't need to sanitize
+      // because we are not inserting markup in the DOM.
+      if (!this._isBrowser || !this._optimizeForSpeed) {
+        css = sanitize(css)
+      }
       const idcss = id + css
       if (!cache[idcss]) {
         cache[idcss] = css.replace(selectoPlaceholderRegexp, id)

--- a/test/stylesheet-registry.js
+++ b/test/stylesheet-registry.js
@@ -104,25 +104,6 @@ test('add - sanitizes dynamic CSS on the server', t => {
   ])
 })
 
-test('add - sanitizes dynamic CSS on the client when optimizeForSpeed is false', t => {
-  const registry = makeRegistry({ optimizeForSpeed: false, isBrowser: true })
-
-  registry.add({
-    styleId: '123',
-    css: [
-      'div.__jsx-style-dynamic-selector { color: red</style><script>alert("howdy")</script> }'
-    ],
-    dynamic: ['red</style><script>alert("howdy")</script>']
-  })
-
-  t.deepEqual(registry.cssRules(), [
-    [
-      'jsx-1871671996',
-      'div.jsx-1871671996 { color: red<\\/style><script>alert("howdy")</script> }'
-    ]
-  ])
-})
-
 // registry.remove
 
 test('remove', t => {

--- a/test/stylesheet-registry.js
+++ b/test/stylesheet-registry.js
@@ -5,7 +5,7 @@ import test from 'ava'
 import StyleSheetRegistry from '../src/stylesheet-registry'
 import makeSheet, { invalidRules } from './stylesheet'
 
-function makeRegistry(options) {
+function makeRegistry(options = { optimizeForSpeed: true, isBrowser: true }) {
   const registry = new StyleSheetRegistry({
     styleSheet: makeSheet(options),
     ...options
@@ -82,6 +82,44 @@ test('add - filters out invalid rules (index `-1`)', t => {
   t.deepEqual(registry.cssRules(), [
     ['jsx-123', 'div { color: red }'],
     ['jsx-678', 'div { color: red }']
+  ])
+})
+
+test('add - sanitizes dynamic CSS on the server', t => {
+  const registry = makeRegistry({ optimizeForSpeed: false, isBrowser: false })
+
+  registry.add({
+    styleId: '123',
+    css: [
+      'div.__jsx-style-dynamic-selector { color: red</style><script>alert("howdy")</script> }'
+    ],
+    dynamic: ['red</style><script>alert("howdy")</script>']
+  })
+
+  t.deepEqual(registry.cssRules(), [
+    [
+      'jsx-1871671996',
+      'div.jsx-1871671996 { color: red<\\/style><script>alert("howdy")</script> }'
+    ]
+  ])
+})
+
+test('add - sanitizes dynamic CSS on the client when optimizeForSpeed is false', t => {
+  const registry = makeRegistry({ optimizeForSpeed: false, isBrowser: true })
+
+  registry.add({
+    styleId: '123',
+    css: [
+      'div.__jsx-style-dynamic-selector { color: red</style><script>alert("howdy")</script> }'
+    ],
+    dynamic: ['red</style><script>alert("howdy")</script>']
+  })
+
+  t.deepEqual(registry.cssRules(), [
+    [
+      'jsx-1871671996',
+      'div.jsx-1871671996 { color: red<\\/style><script>alert("howdy")</script> }'
+    ]
   ])
 })
 
@@ -196,7 +234,9 @@ test('createComputeId', t => {
 // createComputeSelector
 
 test('createComputeSelector', t => {
-  const computeSelector = utilRegistry.createComputeSelector()
+  const computeSelector = utilRegistry
+    .createComputeSelector()
+    .bind(utilRegistry)
 
   t.is(
     computeSelector(


### PR DESCRIPTION
We are not going to sanitize dynamic props on the client when using CSSOM API since we don't inject dom/strings.