### PR TITLE
Don't use deprecated lifecycle hook

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -4,6 +4,11 @@ import StyleSheetRegistry from './stylesheet-registry'
 const styleSheetRegistry = new StyleSheetRegistry()
 
 export default class JSXStyle extends Component {
+  constructor(props) {
+    super(props)
+    styleSheetRegistry.add(this.props)
+  }
+
   static dynamic(info) {
     return info
       .map(tagInfo => {
@@ -11,10 +16,6 @@ export default class JSXStyle extends Component {
         return styleSheetRegistry.computeId(baseId, props)
       })
       .join(' ')
-  }
-
-  componentWillMount() {
-    styleSheetRegistry.add(this.props)
   }
 
   shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
When testing my app using [`React.StrictMode`](https://reactjs.org/docs/strict-mode.html), it complains about the usage of this lifecycle hook. It also complains about the `componentWillUpdate` one, but it seems like it has to stay to avoid flashes of unstyled content.