### PR TITLE
Feature/dynamic elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "10"

--- a/src/babel.js
+++ b/src/babel.js
@@ -41,11 +41,16 @@ export default function({ types: t }) {
           state.ignoreClosing = 0
         }
 
+        const tag = path.get('name')
+
         if (
           name &&
           name !== 'style' &&
           name !== STYLE_COMPONENT &&
           (name.charAt(0) !== name.charAt(0).toUpperCase() ||
+            Object.values(path.scope.bindings).some(binding =>
+              binding.referencePaths.some(r => r === tag)
+            ) ||
             (attributes &&
               Object.values(attributes).some(
                 ({ name, type }) =>

--- a/src/babel.js
+++ b/src/babel.js
@@ -26,7 +26,6 @@ export default function({ types: t }) {
       JSXOpeningElement(path, state) {
         const el = path.node
         const { name } = el.name || {}
-        const { attributes } = el || {}
 
         if (!state.hasJSXStyle) {
           return
@@ -50,12 +49,7 @@ export default function({ types: t }) {
           (name.charAt(0) !== name.charAt(0).toUpperCase() ||
             Object.values(path.scope.bindings).some(binding =>
               binding.referencePaths.some(r => r === tag)
-            ) ||
-            (attributes &&
-              Object.values(attributes).some(
-                ({ name, type }) =>
-                  type === 'JSXAttribute' && name.name === 'styled-jsx'
-              )))
+            ))
         ) {
           if (state.className) {
             addClassName(path, state.className)

--- a/src/babel.js
+++ b/src/babel.js
@@ -26,6 +26,7 @@ export default function({ types: t }) {
       JSXOpeningElement(path, state) {
         const el = path.node
         const { name } = el.name || {}
+        const { attributes } = el || {}
 
         if (!state.hasJSXStyle) {
           return
@@ -44,7 +45,12 @@ export default function({ types: t }) {
           name &&
           name !== 'style' &&
           name !== STYLE_COMPONENT &&
-          name.charAt(0) !== name.charAt(0).toUpperCase()
+          (name.charAt(0) !== name.charAt(0).toUpperCase() ||
+            (attributes &&
+              Object.values(attributes).some(
+                ({ name, type }) =>
+                  type === 'JSXAttribute' && name.name === 'styled-jsx'
+              )))
         ) {
           if (state.className) {
             addClassName(path, state.className)

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -100,6 +100,8 @@ exports[`rewrites className 1`] = `
 "var _this = this;
 
 import _JSXStyle from \\"styled-jsx/style\\";
+const Element = 'div';
+
 export default (() => <div className={\\"jsx-2886504620\\"}>
     <div {...test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.className != null && test.test.className || \\"test\\")} />
     <div {...test.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.test.className != null && test.test.test.className || \\"test\\")} />
@@ -135,6 +137,9 @@ export default (() => <div className={\\"jsx-2886504620\\"}>
     <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
     <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
     <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
+    <Element styled-jsx className={\\"jsx-2886504620\\"} />
+    <Element styled-jsx className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
+    <Element styled-jsx {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
     <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />
   </div>);"
 `;

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -100,9 +100,9 @@ exports[`rewrites className 1`] = `
 "var _this = this;
 
 import _JSXStyle from \\"styled-jsx/style\\";
-const Element = 'div';
-
-export default (() => <div className={\\"jsx-2886504620\\"}>
+export default (() => {
+  const Element = 'div';
+  return <div className={\\"jsx-2886504620\\"}>
     <div {...test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.className != null && test.test.className || \\"test\\")} />
     <div {...test.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.test.className != null && test.test.test.className || \\"test\\")} />
     <div {..._this.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (_this.test.test.className != null && _this.test.test.className || \\"test\\")} />
@@ -137,9 +137,10 @@ export default (() => <div className={\\"jsx-2886504620\\"}>
     <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
     <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
     <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
-    <Element styled-jsx className={\\"jsx-2886504620\\"} />
-    <Element styled-jsx className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
-    <Element styled-jsx {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
+    <Element className={\\"jsx-2886504620\\"} />
+    <Element className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
+    <Element {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
     <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />
-  </div>);"
+  </div>;
+});"
 `;

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -103,44 +103,44 @@ import _JSXStyle from \\"styled-jsx/style\\";
 export default (() => {
   const Element = 'div';
   return <div className={\\"jsx-2886504620\\"}>
-    <div {...test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.className != null && test.test.className || \\"test\\")} />
-    <div {...test.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.test.className != null && test.test.test.className || \\"test\\")} />
-    <div {..._this.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (_this.test.test.className != null && _this.test.test.className || \\"test\\")} />
-    <div data-test=\\"test\\" className={\\"jsx-2886504620\\"} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + \`test\`} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + \`test\${true ? ' test2' : ''}\`} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + ('test ' + test || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (['test', 'test2'].join(' ') || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (true && 'test' || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + ((test ? 'test' : null) || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (test || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (test && 'test' || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (test && test('test') || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (undefined || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (null || \\"\\")} />
-    <div className={\\"jsx-2886504620\\" + \\" \\" + (false || \\"\\")} />
-    <div data-test className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
-    <div data-test className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
-    <div data-test=\\"test\\" className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || 'test')} />
-    <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || 'test')} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \`test \${test ? 'test' : ''}\`)} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || test && test('test') || \\"\\")} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || test && test('test') && 'test' || \\"\\")} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || test && test('test') && test2('test') || \\"\\")} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
-    <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
-    <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
-    <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
-    <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
-    <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
-    <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
-    <Element className={\\"jsx-2886504620\\"} />
-    <Element className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
-    <Element {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
-    <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />
-  </div>;
+      <div {...test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.className != null && test.test.className || \\"test\\")} />
+      <div {...test.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (test.test.test.className != null && test.test.test.className || \\"test\\")} />
+      <div {..._this.test.test} className={\\"jsx-2886504620\\" + \\" \\" + (_this.test.test.className != null && _this.test.test.className || \\"test\\")} />
+      <div data-test=\\"test\\" className={\\"jsx-2886504620\\"} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + \`test\`} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + \`test\${true ? ' test2' : ''}\`} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + ('test ' + test || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (['test', 'test2'].join(' ') || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (true && 'test' || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + ((test ? 'test' : null) || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (test || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (test && 'test' || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (test && test('test') || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (undefined || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (null || \\"\\")} />
+      <div className={\\"jsx-2886504620\\" + \\" \\" + (false || \\"\\")} />
+      <div data-test className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
+      <div data-test className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
+      <div data-test=\\"test\\" className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || 'test')} />
+      <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || 'test')} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \`test \${test ? 'test' : ''}\`)} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || test && test('test') || \\"\\")} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || test && test('test') && 'test' || \\"\\")} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || test && test('test') && test2('test') || \\"\\")} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
+      <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + 'test'} />
+      <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
+      <div {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
+      <div {...props} {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
+      <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || props.className != null && props.className || \\"\\")} />
+      <div {...props} data-foo {...rest} className={\\"jsx-2886504620\\" + \\" \\" + (rest.className != null && rest.className || 'test')} />
+      <Element className={\\"jsx-2886504620\\"} />
+      <Element className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
+      <Element {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
+      <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />
+    </div>;
 });"
 `;

--- a/test/__snapshots__/external.js.snap
+++ b/test/__snapshots__/external.js.snap
@@ -148,6 +148,20 @@ export default {
 };"
 `;
 
+exports[`use external stylesheet and dynamic element 1`] = `
+"import _JSXStyle from \\"styled-jsx/style\\";
+import styles from './styles2';
+
+export default (({ level = 1 }) => {
+  const Element = \`h\${level}\`;
+
+  return <Element className={\`jsx-\${styles.__scopedHash}\` + \\" \\" + \\"root\\"}>
+      <p className={\`jsx-\${styles.__scopedHash}\`}>dynamic element</p>
+      <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    </Element>;
+});"
+`;
+
 exports[`use external stylesheets (global only) 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 import styles, { foo as styles3 } from './styles';

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -112,7 +112,52 @@ export default (({ level = 1 }) => {
       <p className={\\"jsx-1253978709\\"}>dynamic element</p>
       <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
     </Element>;
-});"
+});
+
+export const TestLowerCase = ({ level = 1 }) => {
+  const element = \`h\${level}\`;
+
+  return <element className={\\"jsx-1253978709\\" + \\" \\" + \\"root\\"}>
+      <p className={\\"jsx-1253978709\\"}>dynamic element</p>
+      <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
+    </element>;
+};
+
+const Element2 = 'div';
+export const Test2 = () => {
+
+  return <Element2 className=\\"root\\">
+      <p className={\\"jsx-1253978709\\"}>dynamic element</p>
+      <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
+    </Element2>;
+};"
+`;
+
+exports[`works with dynamic element in class 1`] = `
+"import _JSXStyle from 'styled-jsx/style';
+export default class {
+  render() {
+    const Element = 'div';
+
+    return <Element className={'jsx-1800172487' + ' ' + 'root'}>
+        <p className={\\"jsx-1800172487\\"}>dynamic element</p>
+        <_JSXStyle styleId={\\"1800172487\\"} css={\\".root.jsx-1800172487{background:red;}\\"} />
+      </Element>;
+  }
+
+}
+
+const Element2 = 'div';
+export const Test2 = class {
+  render() {
+
+    return <Element2 className=\\"root\\">
+        <p className={\\"jsx-1800172487\\"}>dynamic element</p>
+        <_JSXStyle styleId={\\"1800172487\\"} css={\\".root.jsx-1800172487{background:red;}\\"} />
+      </Element2>;
+  }
+
+};"
 `;
 
 exports[`works with expressions in template literals 1`] = `

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -125,7 +125,6 @@ export const TestLowerCase = ({ level = 1 }) => {
 
 const Element2 = 'div';
 export const Test2 = () => {
-
   return <Element2 className=\\"root\\">
       <p className={\\"jsx-1253978709\\"}>dynamic element</p>
       <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
@@ -144,19 +143,16 @@ export default class {
         <_JSXStyle styleId={\\"1800172487\\"} css={\\".root.jsx-1800172487{background:red;}\\"} />
       </Element>;
   }
-
 }
 
 const Element2 = 'div';
 export const Test2 = class {
   render() {
-
     return <Element2 className=\\"root\\">
         <p className={\\"jsx-1800172487\\"}>dynamic element</p>
         <_JSXStyle styleId={\\"1800172487\\"} css={\\".root.jsx-1800172487{background:red;}\\"} />
       </Element2>;
   }
-
 };"
 `;
 

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -103,6 +103,18 @@ class Test extends React.Component {
 }"
 `;
 
+exports[`works with dynamic element 1`] = `
+"import _JSXStyle from \\"styled-jsx/style\\";
+export default (({ level = 1 }) => {
+  const Element = \`h\${level}\`;
+
+  return <Element styled-jsx className={\\"jsx-1253978709\\" + \\" \\" + \\"root\\"}>
+      <p className={\\"jsx-1253978709\\"}>dynamic element</p>
+      <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
+    </Element>;
+});"
+`;
+
 exports[`works with expressions in template literals 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 const darken = c => c;

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -108,7 +108,7 @@ exports[`works with dynamic element 1`] = `
 export default (({ level = 1 }) => {
   const Element = \`h\${level}\`;
 
-  return <Element styled-jsx className={\\"jsx-1253978709\\" + \\" \\" + \\"root\\"}>
+  return <Element className={\\"jsx-1253978709\\" + \\" \\" + \\"root\\"}>
       <p className={\\"jsx-1253978709\\"}>dynamic element</p>
       <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
     </Element>;

--- a/test/external.js
+++ b/test/external.js
@@ -88,3 +88,8 @@ test('injects JSXStyle for nested scope', async t => {
   `)
   t.snapshot(code)
 })
+
+test('use external stylesheet and dynamic element', async t => {
+  const { code } = await transform('./fixtures/dynamic-element-external.js')
+  t.snapshot(code)
+})

--- a/test/fixtures/attribute-generation-classname-rewriting.js
+++ b/test/fixtures/attribute-generation-classname-rewriting.js
@@ -1,3 +1,5 @@
+const Element = 'div'
+
 export default () => (
   <div>
     <div className="test" {...test.test} />
@@ -34,6 +36,9 @@ export default () => (
     <div {...props} {...rest} />
     <div {...props} data-foo {...rest} />
     <div {...props} className={'test'} data-foo {...rest} />
+    <Element styled-jsx />
+    <Element styled-jsx className="test" />
+    <Element styled-jsx {...props} />
     <style jsx>{'div { color: red }'}</style>
   </div>
 )

--- a/test/fixtures/attribute-generation-classname-rewriting.js
+++ b/test/fixtures/attribute-generation-classname-rewriting.js
@@ -1,44 +1,45 @@
-const Element = 'div'
-
-export default () => (
-  <div>
-    <div className="test" {...test.test} />
-    <div className="test" {...test.test.test} />
-    <div className="test" {...this.test.test} />
-    <div data-test="test" />
-    <div className="test" />
-    <div className={'test'} />
-    <div className={`test`} />
-    <div className={`test${true ? ' test2' : ''}`} />
-    <div className={'test ' + test} />
-    <div className={['test', 'test2'].join(' ')} />
-    <div className={true && 'test'} />
-    <div className={test ? 'test' : null} />
-    <div className={test} />
-    <div className={test && 'test'} />
-    <div className={test && test('test')} />
-    <div className={undefined} />
-    <div className={null} />
-    <div className={false} />
-    <div className={'test'} data-test />
-    <div data-test className={'test'} />
-    <div className={'test'} data-test="test" />
-    <div className={'test'} {...props} />
-    <div className={'test'} {...props} {...rest} />
-    <div className={`test ${test ? 'test' : ''}`} {...props} />
-    <div className={test && test('test')} {...props} />
-    <div className={test && test('test') && 'test'} {...props} />
-    <div className={test && test('test') && test2('test')} {...props} />
-    <div {...props} className={'test'} />
-    <div {...props} {...rest} className={'test'} />
-    <div {...props} className={'test'} {...rest} />
-    <div {...props} />
-    <div {...props} {...rest} />
-    <div {...props} data-foo {...rest} />
-    <div {...props} className={'test'} data-foo {...rest} />
-    <Element styled-jsx />
-    <Element styled-jsx className="test" />
-    <Element styled-jsx {...props} />
-    <style jsx>{'div { color: red }'}</style>
-  </div>
-)
+export default () => {
+  const Element = 'div'
+  return (
+    <div>
+      <div className="test" {...test.test} />
+      <div className="test" {...test.test.test} />
+      <div className="test" {...this.test.test} />
+      <div data-test="test" />
+      <div className="test" />
+      <div className={'test'} />
+      <div className={`test`} />
+      <div className={`test${true ? ' test2' : ''}`} />
+      <div className={'test ' + test} />
+      <div className={['test', 'test2'].join(' ')} />
+      <div className={true && 'test'} />
+      <div className={test ? 'test' : null} />
+      <div className={test} />
+      <div className={test && 'test'} />
+      <div className={test && test('test')} />
+      <div className={undefined} />
+      <div className={null} />
+      <div className={false} />
+      <div className={'test'} data-test />
+      <div data-test className={'test'} />
+      <div className={'test'} data-test="test" />
+      <div className={'test'} {...props} />
+      <div className={'test'} {...props} {...rest} />
+      <div className={`test ${test ? 'test' : ''}`} {...props} />
+      <div className={test && test('test')} {...props} />
+      <div className={test && test('test') && 'test'} {...props} />
+      <div className={test && test('test') && test2('test')} {...props} />
+      <div {...props} className={'test'} />
+      <div {...props} {...rest} className={'test'} />
+      <div {...props} className={'test'} {...rest} />
+      <div {...props} />
+      <div {...props} {...rest} />
+      <div {...props} data-foo {...rest} />
+      <div {...props} className={'test'} data-foo {...rest} />
+      <Element />
+      <Element className="test" />
+      <Element {...props} />
+      <style jsx>{'div { color: red }'}</style>
+    </div>
+  )
+}

--- a/test/fixtures/dynamic-element-class.js
+++ b/test/fixtures/dynamic-element-class.js
@@ -1,0 +1,32 @@
+export default class {
+  render() {
+    const Element = 'div'
+
+    return (
+      <Element className="root">
+        <p>dynamic element</p>
+        <style jsx>{`
+          .root {
+            background: red;
+          }
+        `}</style>
+      </Element>
+    )
+  }
+}
+
+const Element2 = 'div'
+export const Test2 = class {
+  render() {
+    return (
+      <Element2 className="root">
+        <p>dynamic element</p>
+        <style jsx>{`
+          .root {
+            background: red;
+          }
+        `}</style>
+      </Element2>
+    )
+  }
+}

--- a/test/fixtures/dynamic-element-external.js
+++ b/test/fixtures/dynamic-element-external.js
@@ -1,0 +1,12 @@
+import styles from './styles2'
+
+export default ({ level = 1 }) => {
+  const Element = `h${level}`
+
+  return (
+    <Element className="root">
+      <p>dynamic element</p>
+      <style jsx>{styles}</style>
+    </Element>
+  )
+}

--- a/test/fixtures/dynamic-element.js
+++ b/test/fixtures/dynamic-element.js
@@ -2,7 +2,7 @@ export default ({ level = 1 }) => {
   const Element = `h${level}`
 
   return (
-    <Element styled-jsx className="root">
+    <Element className="root">
       <p>dynamic element</p>
       <style jsx>{`
         .root {

--- a/test/fixtures/dynamic-element.js
+++ b/test/fixtures/dynamic-element.js
@@ -1,0 +1,14 @@
+export default ({ level = 1 }) => {
+  const Element = `h${level}`
+
+  return (
+    <Element styled-jsx className="root">
+      <p>dynamic element</p>
+      <style jsx>{`
+        .root {
+          background: red;
+        }
+      `}</style>
+    </Element>
+  )
+}

--- a/test/fixtures/dynamic-element.js
+++ b/test/fixtures/dynamic-element.js
@@ -12,3 +12,32 @@ export default ({ level = 1 }) => {
     </Element>
   )
 }
+
+export const TestLowerCase = ({ level = 1 }) => {
+  const element = `h${level}`
+
+  return (
+    <element className="root">
+      <p>dynamic element</p>
+      <style jsx>{`
+        .root {
+          background: red;
+        }
+      `}</style>
+    </element>
+  )
+}
+
+const Element2 = 'div'
+export const Test2 = () => {
+  return (
+    <Element2 className="root">
+      <p>dynamic element</p>
+      <style jsx>{`
+        .root {
+          background: red;
+        }
+      `}</style>
+    </Element2>
+  )
+}

--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,11 @@ test('works with dynamic element', async t => {
   t.snapshot(code)
 })
 
+test('works with dynamic element in class', async t => {
+  const { code } = await transform('./fixtures/dynamic-element-class.js')
+  t.snapshot(code)
+})
+
 test('does not transpile nested style tags', async t => {
   const { message } = await t.throws(
     transform('./fixtures/nested-style-tags.js')

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,11 @@ test('works with css tagged template literals in the same file', async t => {
   t.snapshot(code)
 })
 
+test('works with dynamic element', async t => {
+  const { code } = await transform('./fixtures/dynamic-element.js')
+  t.snapshot(code)
+})
+
 test('does not transpile nested style tags', async t => {
   const { message } = await t.throws(
     transform('./fixtures/nested-style-tags.js')


### PR DESCRIPTION
Related issue https://github.com/zeit/styled-jsx/issues/147

Based on comment by @giuseppeg 

Automaticly scopes elements if possible ( works if declared inside of component )

for other cases a styled-jsx prop can be added

```javascript
// works
const Cmp = () => {
  const Element = 'div';
  return (<Element className="foo">
    <style jsx>{`.foo{...}`}</style>
  </Element>)
}

// wont work
const Element = 'div';
const Cmp = () => (<Element className="foo">
  <style jsx>{`.foo{...}`}</style>
</Element>)

// works
const Element = 'div';
const Cmp = () => (<Element className="foo" styled-jsx>
  <style jsx>{`.foo{...}`}</style>
</Element>)
```