### PR TITLE
Fix external styles references

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -113,7 +113,7 @@ export default function({ types: t }) {
                 state.externalStyles.push([
                   t.memberExpression(
                     externalStylesIdentifier,
-                    t.identifier(isGlobal ? '__hash' : '__scopedHash')
+                    t.identifier('__hash')
                   ),
                   externalStylesIdentifier,
                   isGlobal
@@ -220,19 +220,9 @@ export default function({ types: t }) {
               return expression && expression.isIdentifier()
             }).length === 1
           ) {
-            const [id, css, isGlobal] = state.externalStyles.shift()
+            const [id, css] = state.externalStyles.shift()
 
-            path.replaceWith(
-              makeStyledJsxTag(
-                id,
-                isGlobal
-                  ? css
-                  : t.memberExpression(
-                      t.identifier(css.name),
-                      t.identifier('__scoped')
-                    )
-              )
-            )
+            path.replaceWith(makeStyledJsxTag(id, css))
             return
           }
 

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -7,32 +7,32 @@ import styles from './styles';
 const styles2 = require('./styles2');
 
 // external only
-export const Test1 = () => <div className={\`jsx-\${styles.__scopedHash} jsx-\${styles2.__scopedHash}\`}>
-    <p className={\`jsx-\${styles.__scopedHash} jsx-\${styles2.__scopedHash}\`}>external only</p>
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
-    <_JSXStyle styleId={styles2.__scopedHash} css={styles2.__scoped} />
+export const Test1 = () => <div className={\`jsx-\${styles.__hash} jsx-\${styles2.__hash}\`}>
+    <p className={\`jsx-\${styles.__hash} jsx-\${styles2.__hash}\`}>external only</p>
+    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle styleId={styles2.__hash} css={styles2} />
   </div>;
 
 // external and static
-export const Test2 = () => <div className={'jsx-2982525546 ' + \`jsx-\${styles.__scopedHash}\`}>
-    <p className={'jsx-2982525546 ' + \`jsx-\${styles.__scopedHash}\`}>external and static</p>
+export const Test2 = () => <div className={'jsx-2982525546 ' + \`jsx-\${styles.__hash}\`}>
+    <p className={'jsx-2982525546 ' + \`jsx-\${styles.__hash}\`}>external and static</p>
     <_JSXStyle styleId={\\"2982525546\\"} css={\\"p.jsx-2982525546{color:red;}\\"} />
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>;
 
 // external and dynamic
-export const Test3 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>
-    <p className={\`jsx-\${styles.__scopedHash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>external and dynamic</p>
+export const Test3 = ({ color }) => <div className={\`jsx-\${styles.__hash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>
+    <p className={\`jsx-\${styles.__hash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>external and dynamic</p>
     <_JSXStyle styleId={\\"1947484460\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>;
 
 // external, static and dynamic
-export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
-    <p className={\`jsx-\${styles.__scopedHash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>external, static and dynamic</p>
+export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__hash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
+    <p className={\`jsx-\${styles.__hash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>external, static and dynamic</p>
     <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block;}\\"} />
     <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>;
 
 // static only

--- a/test/__snapshots__/external.js.snap
+++ b/test/__snapshots__/external.js.snap
@@ -155,9 +155,9 @@ import styles from './styles2';
 export default (({ level = 1 }) => {
   const Element = \`h\${level}\`;
 
-  return <Element className={\`jsx-\${styles.__scopedHash}\` + \\" \\" + \\"root\\"}>
-      <p className={\`jsx-\${styles.__scopedHash}\`}>dynamic element</p>
-      <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+  return <Element className={\`jsx-\${styles.__hash}\` + \\" \\" + \\"root\\"}>
+      <p className={\`jsx-\${styles.__hash}\`}>dynamic element</p>
+      <_JSXStyle styleId={styles.__hash} css={styles} />
     </Element>;
 });"
 `;
@@ -182,9 +182,9 @@ exports[`use external stylesheets (multi-line) 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 import styles from './styles';
 
-export default (() => <div className={\`jsx-\${styles.__scopedHash}\`}>
-    <p className={\`jsx-\${styles.__scopedHash}\`}>test</p>
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+export default (() => <div className={\`jsx-\${styles.__hash}\`}>
+    <p className={\`jsx-\${styles.__hash}\`}>test</p>
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>);"
 `;
 
@@ -194,21 +194,21 @@ import styles from './styles';
 const styles2 = require('./styles2');
 import { foo as styles3 } from './styles';
 
-export default (() => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`}>
-    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\` + ' ' + 'foo'}>test</p>
-    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`}>woot</p>
+export default (() => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\`}>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\` + ' ' + 'foo'}>test</p>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\`}>woot</p>
     <_JSXStyle styleId={styles2.__hash} css={styles2} />
-    <_JSXStyle styleId={styles3.__scopedHash} css={styles3.__scoped} />
-    <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash} jsx-\${styles.__scopedHash}\`}>woot</div>
+    <_JSXStyle styleId={styles3.__hash} css={styles3} />
+    <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\`}>woot</div>
     <_JSXStyle styleId={\\"1646697228\\"} css={\\"p.jsx-1646697228{color:red;}div.jsx-1646697228{color:green;}\\"} />
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>);
 
-export const Test = () => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\`}>
-    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\` + ' ' + 'foo'}>test</p>
-    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\`}>woot</p>
-    <_JSXStyle styleId={styles3.__scopedHash} css={styles3.__scoped} />
-    <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__scopedHash}\`}>woot</div>
+export const Test = () => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\`}>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\` + ' ' + 'foo'}>test</p>
+    <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\`}>woot</p>
+    <_JSXStyle styleId={styles3.__hash} css={styles3} />
+    <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\`}>woot</div>
     <_JSXStyle styleId={\\"1646697228\\"} css={\\"p.jsx-1646697228{color:red;}div.jsx-1646697228{color:green;}\\"} />
   </div>;"
 `;

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -85,9 +85,9 @@ exports[`works with css tagged template literals in the same file 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 
 
-export default (({ children }) => <div className={\`jsx-\${styles.__scopedHash}\`}>
-    <p className={\`jsx-\${styles.__scopedHash}\`}>{children}</p>
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+export default (({ children }) => <div className={\`jsx-\${styles.__hash}\`}>
+    <p className={\`jsx-\${styles.__hash}\`}>{children}</p>
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>);
 
 const styles = new String('p.jsx-2587355013{color:red;}');
@@ -95,9 +95,9 @@ const styles = new String('p.jsx-2587355013{color:red;}');
 styles.__hash = '2587355013';
 class Test extends React.Component {
   render() {
-    return <div className={\`jsx-\${styles.__scopedHash}\`}>
-        <p className={\`jsx-\${styles.__scopedHash}\`}>{this.props.children}</p>
-        <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    return <div className={\`jsx-\${styles.__hash}\`}>
+        <p className={\`jsx-\${styles.__hash}\`}>{this.props.children}</p>
+        <_JSXStyle styleId={styles.__hash} css={styles} />
       </div>;
   }
 }"

--- a/test/__snapshots__/plugins.js.snap
+++ b/test/__snapshots__/plugins.js.snap
@@ -5,10 +5,10 @@ exports[`applies plugins 1`] = `
 import styles from './styles';
 const color = 'red';
 
-export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>
-    <p className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>test</p>
+export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>
+    <p className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>test</p>
     <_JSXStyle styleId={\\"3382438999\\"} css={\`span.\${color}.jsx-3382438999{color:\${otherColor};}\`} />
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>);"
 `;
 
@@ -17,9 +17,9 @@ exports[`passes options to plugins 1`] = `
 import styles from './styles';
 const color = 'red';
 
-export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>
-    <p className={'jsx-3382438999 ' + \`jsx-\${styles.__scopedHash}\`}>test</p>
+export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>
+    <p className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>test</p>
     <_JSXStyle styleId={\\"3382438999\\"} css={\\".test.jsx-3382438999{content:\\\\\\"{\\\\\\"foo\\\\\\":false,\\\\\\"babel\\\\\\":{\\\\\\"location\\\\\\":{\\\\\\"start\\\\\\":{\\\\\\"line\\\\\\":7,\\\\\\"column\\\\\\":16},\\\\\\"end\\\\\\":{\\\\\\"line\\\\\\":11,\\\\\\"column\\\\\\":5}},\\\\\\"vendorPrefixes\\\\\\":false,\\\\\\"sourceMaps\\\\\\":false,\\\\\\"isGlobal\\\\\\":false}}\\\\\\";}\\"} />
-    <_JSXStyle styleId={styles.__scopedHash} css={styles.__scoped} />
+    <_JSXStyle styleId={styles.__hash} css={styles} />
   </div>);"
 `;


### PR DESCRIPTION
In #442 I rewrote `styled-jsx/css` so that now we have a separate function to define global styles `css.global` while `css` compiles to scoped styles. Before `css` was transpiling as following:

```js
const styles = css`div { color: red }`

// became
const styles = new String('div { color: red }')
styles.__hash = '1230' // the trailing 0 for global
styles.__scoped = 'div.jsx-1231' 
styles.__scopedHashh = '1231' // the trailing 1 for scoped
```

This is because we didn't know the intent of the user. With #442 though we made this explicit so we got rid of `__scopedHash` and `__scoped` but I forgot to remove the references from `babel.js` - this PR fixes this issue.

The new output:

```js
const styles = css`div { color: red }`
const styles2 = css.global`div { color: red }`

// becomes 
const styles = new String('div.jsx-123 { color: red }')
styles.__hash = '123'

const styles2 = new String('div { color: red }')
styles2.__hash = '456'
```