### PR TITLE
register invalid rules for removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     ],
     "extends": "prettier",
     "ignores": [
-      "lib/style-transform.js"
+      "lib/style-transform.js",
+      "babel-test.js"
     ],
     "rules": {
       "capitalized-comments": 0,

--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -113,10 +113,15 @@ export default class StyleSheetRegistry {
     const cssRules = this._sheet.cssRules()
 
     return fromServer.concat(
-      Object.keys(this._indices).map(styleId => [
-        styleId,
-        this._indices[styleId].map(index => cssRules[index].cssText).join('\n')
-      ])
+      Object.keys(this._indices)
+        .map(styleId => [
+          styleId,
+          this._indices[styleId]
+            .map(index => cssRules[index].cssText)
+            .join('\n')
+        ])
+        // filter out empty rules
+        .filter(rule => Boolean(rule[1]))
     )
   }
 

--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -62,10 +62,8 @@ export default class StyleSheetRegistry {
       // Filter out invalid rules
       .filter(index => index !== -1)
 
-    if (indices.length > 0) {
-      this._indices[styleId] = indices
-      this._instancesCounts[styleId] = 1
-    }
+    this._indices[styleId] = indices
+    this._instancesCounts[styleId] = 1
   }
 
   remove(props) {

--- a/test/stylesheet-registry.js
+++ b/test/stylesheet-registry.js
@@ -92,6 +92,23 @@ test(
   })
 )
 
+test(
+  'it does not throw when inserting an invalid rule',
+  withMock(withMockDocument, t => {
+    const registry = makeRegistry()
+
+    // Insert a valid rule
+    registry.add({ styleId: '123', css: [cssRule] })
+
+    t.notThrows(() => {
+      // Insert an invalid rule
+      registry.add({ styleId: '456', css: [invalidRules[0]] })
+    })
+
+    t.deepEqual(registry.cssRules(), [['jsx-123', 'div { color: red }']])
+  })
+)
+
 test('add - sanitizes dynamic CSS on the server', t => {
   const registry = makeRegistry({ optimizeForSpeed: false, isBrowser: false })
 


### PR DESCRIPTION
Attempts to handle fix mentioned in https://github.com/zeit/styled-jsx/issues/474#issuecomment-413243523

I'm not sure this is exactly the behavior wanted since it's storing an empty string when the rule is invalid (while not keeping the invalid stylesheet).