### PR TITLE
Add styled-jsx/babel-test plugin

### DIFF
--- a/babel-test.js
+++ b/babel-test.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/babel-test')

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lib",
     "server.js",
     "babel.js",
+    "babel-test.js",
     "style.js",
     "macro.js",
     "css.js",

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ Code and docs are for v3 which we highly recommend you to try. Looking for style
 - [CSS Preprocessing via Plugins](#css-preprocessing-via-plugins)
   * [Plugin options](#plugin-options)
   * [Example plugins](#example-plugins)
+- [Rendering in tests](#rendering-in-tests)
 - [FAQ](#faq)
   * [Warning: unknown `jsx` prop on &lt;style&gt; tag](#warning-unknown-jsx-prop-on-style-tag)
   * [Can I return an array of components when using React 16?](#can-i-return-an-array-of-components-when-using-react-16)
@@ -88,7 +89,7 @@ The following are optional settings for the babel plugin.
 
 Blazing fast and optimized CSS rules injection system based on the CSSOM APIs.
 
-```
+```json
 {
   "plugins": [
     ["styled-jsx/babel", { "optimizeForSpeed": true }]
@@ -773,6 +774,38 @@ The following plugins are proof of concepts/sample:
 * [styled-jsx-plugin-stylelint](https://github.com/giuseppeg/styled-jsx-plugin-stylelint)
 * [styled-jsx-plugin-less](https://github.com/erasmo-marin/styled-jsx-plugin-less)
 * [styled-jsx-plugin-stylus](https://github.com/omardelarosa/styled-jsx-plugin-stylus)
+
+
+## Rendering in tests
+
+If you're using a tool such as Enzyme, you might want to avoid compiling your styles in test renders. In general, styled-jsx artifacts like `jsx-123` classnames and vendor prefixing are not direct concerns of your component, and they generate a lot of snapshot noise.
+
+One option is to exclude the `styled-jsx/babel` plugin from the `test` environment using `env` in your Babel config (see [Config Merging options](https://babeljs.io/docs/en/options#config-merging-options)).
+
+But this can cause noise in your terminal output when rendering:
+
+```
+   console.error node_modules/react-dom/cjs/react-dom.development.js:527
+      Warning: Received `true` for a non-boolean attribute `jsx`.
+```
+
+The `styled-jsx/babel-test` solves this problem. It simply strips `jsx` attributes from all `<style>` tags. Be sure to target each environment with the appropriate plugin:
+
+```json
+{
+  "env": {
+    "production": {
+      "plugins": ["styled-jsx/babel"]
+    },
+    "development": {
+      "plugins": ["styled-jsx/babel"]
+    },
+    "test": {
+      "plugins": ["styled-jsx/babel-test"]
+    }
+  }
+}
+```
 
 ## FAQ
 

--- a/src/babel-test.js
+++ b/src/babel-test.js
@@ -1,0 +1,19 @@
+import jsx from 'babel-plugin-syntax-jsx'
+
+export default function() {
+  return {
+    inherits: jsx,
+    visitor: {
+      JSXOpeningElement(path) {
+        const el = path.node
+        const { name } = el.name || {}
+
+        if (name !== 'style') {
+          return
+        }
+
+        el.attributes = el.attributes.filter(a => a.name.name !== 'jsx')
+      }
+    }
+  }
+}

--- a/test/__snapshots__/plugins.js.snap
+++ b/test/__snapshots__/plugins.js.snap
@@ -12,6 +12,21 @@ export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__hash
   </div>);"
 `;
 
+exports[`babel-test plugin strips jsx attribute 1`] = `
+"import styles from './styles';
+const color = 'red';
+
+export default (() => <div>
+    <p>test</p>
+    <style>{\`
+      div.\${color} {
+        color: \${otherColor};
+      }
+    \`}</style>
+    <style>{styles}</style>
+  </div>);"
+`;
+
 exports[`passes options to plugins 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 import styles from './styles';

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -3,6 +3,7 @@ import test from 'ava'
 
 // Ours
 import babelPlugin from '../src/babel'
+import babelTestPlugin from '../src/babel-test'
 import { combinePlugins } from '../src/_utils'
 import _transform from './_transform'
 import testPlugin1 from './fixtures/plugins/plugin'
@@ -76,6 +77,14 @@ test('combinePlugins applies plugins left to right', t => {
 
 test('applies plugins', async t => {
   const { code } = await transform('./fixtures/with-plugins.js')
+  t.snapshot(code)
+})
+
+test('babel-test plugin strips jsx attribute', async t => {
+  const { code } = await transform('./fixtures/with-plugins.js', {
+    plugins: [babelTestPlugin]
+  })
+
   t.snapshot(code)
 })
 


### PR DESCRIPTION
Adds `styled-jsx/babel-test` plugin as per discussion with @giuseppeg.

The readme entry feels a bit long, but I think it's necessary to give some background to explain why you might (or might not) want to use it.

Closes #459.