### PR TITLE
Use debug package in favor of console.log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,21 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -274,6 +289,23 @@
         "debug": "^3.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "@babel/types": {
@@ -2235,12 +2267,18 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
+      "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "decamelize": {
@@ -2597,6 +2635,21 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "strip-ansi": {
@@ -5298,6 +5351,23 @@
             "is-directory": "^0.3.1",
             "js-yaml": "^3.9.0",
             "parse-json": "^4.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            }
           }
         },
         "execa": {
@@ -8657,6 +8727,15 @@
             "quick-lru": "^1.0.0"
           }
         },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "get-stdin": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -8720,6 +8799,12 @@
             "trim-newlines": "^2.0.0",
             "yargs-parser": "^10.0.0"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         },
         "parse-json": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "babel-plugin-syntax-jsx": "6.18.0",
     "babel-types": "6.26.0",
     "convert-source-map": "1.5.1",
+    "debug": "4.0.1",
     "loader-utils": "1.1.0",
     "source-map": "0.7.3",
     "string-hash": "1.1.3",

--- a/readme.md
+++ b/readme.md
@@ -776,6 +776,10 @@ The following plugins are proof of concepts/sample:
 * [styled-jsx-plugin-stylus](https://github.com/omardelarosa/styled-jsx-plugin-stylus)
 
 
+#### Debugging plugins
+
+Use `DEBUG=styled-jsx ./my-build-script` to log plugin usage.
+
 ## Rendering in tests
 
 If you're using a tool such as Enzyme, you might want to avoid compiling your styles in test renders. In general, styled-jsx artifacts like `jsx-123` classnames and vendor prefixing are not direct concerns of your component, and they generate a lot of snapshot noise.

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import * as t from 'babel-types'
 import _hashString from 'string-hash'
 import { SourceMapGenerator } from 'source-map'
@@ -13,6 +14,7 @@ import {
   STYLE_COMPONENT_DYNAMIC
 } from './_constants'
 
+const log = debug('styled-jsx')
 const concat = (a, b) => t.binaryExpression('+', a, b)
 const and = (a, b) => t.logicalExpression('&&', a, b)
 const or = (a, b) => t.logicalExpression('||', a, b)
@@ -639,8 +641,4 @@ export const setStateOptions = state => {
       vendorPrefixes: state.opts.vendorPrefixes
     })
   }
-}
-
-export function log(message) {
-  console.log('[styled-jsx] ' + message)
 }


### PR DESCRIPTION
I use style-jsx-plugin-sass in my project, as you can see - and recently updated to 3.1.0 to find that I get a lot of this in my build.

```
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
[styled-jsx] Loading plugin from path: styled-jsx-plugin-sass
```

This PR simply utilizes the [debug](https://www.npmjs.com/package/debug) package to quiet the output and allow users to opt-in to this behavior instead of enforcing it.

```
DEBUG=styled-jsx npm run test
```

Produces the following:

```
2018-10-08T04:13:08.804Z styled-jsx Loading plugin from path: ~/styled-jsx/test/fixtures/plugins/another-plugin.js
2018-10-08T04:13:08.839Z styled-jsx Loading plugin from path: ~/styled-jsx/test/fixtures/plugins/options.js
2018-10-08T04:13:08.839Z styled-jsx Loading plugin from path: ~/styled-jsx/test/fixtures/plugins/multiple-options.js
2018-10-08T04:13:08.873Z styled-jsx Loading plugin from path: ~/styled-jsx/test/fixtures/plugins/multiple-options.js
```

Note, the timestamp in front is because the tests run in a non TTY environment; for most people it will output a colored string "styled-jsx".
