### PR TITLE
Enable logging only development

### DIFF
--- a/src/_utils.js
+++ b/src/_utils.js
@@ -642,5 +642,5 @@ export const setStateOptions = state => {
 }
 
 export function log(message) {
-  console.log('[styled-jsx] ' + message)
+  process.env.NODE_ENV === 'development' && console.log('[styled-jsx] ' + message)
 }


### PR DESCRIPTION
When you configure plugins for `styled-jsx` you get huge amount of logs with every jsx tag.
so a quick solution is to allow this log only on development ENV, or other ideas are welcome :) 
Currently it so annoying to get this logs in the build!