### PR TITLE
Shorten JSXStyle generated prop names. Fix #530

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ import _JSXStyle from 'styled-jsx/style'
 export default () => (
   <div className="jsx-123">
     <p className="jsx-123">only this paragraph will get the style :)</p>
-    <_JSXStyle styleId="123" css={`p.jsx-123 {color: red;}`} />
+    <_JSXStyle id="123">{`p.jsx-123 {color: red;}`}</_JSXStyle>
   </div>
 )
 ```

--- a/src/_constants.js
+++ b/src/_constants.js
@@ -1,6 +1,5 @@
 export const GLOBAL_ATTRIBUTE = 'global'
 export const STYLE_ATTRIBUTE = 'jsx'
 export const STYLE_COMPONENT = '_JSXStyle'
-export const STYLE_COMPONENT_CSS = 'css'
 export const STYLE_COMPONENT_DYNAMIC = 'dynamic'
-export const STYLE_COMPONENT_ID = 'styleId'
+export const STYLE_COMPONENT_ID = 'id'

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -9,7 +9,6 @@ import {
   GLOBAL_ATTRIBUTE,
   STYLE_COMPONENT_ID,
   STYLE_COMPONENT,
-  STYLE_COMPONENT_CSS,
   STYLE_COMPONENT_DYNAMIC
 } from './_constants'
 
@@ -410,10 +409,6 @@ export const makeStyledJsxTag = (id, transformedCss, expressions = []) => {
       t.jSXExpressionContainer(
         typeof id === 'string' ? t.stringLiteral(id) : id
       )
-    ),
-    t.jSXAttribute(
-      t.jSXIdentifier(STYLE_COMPONENT_CSS),
-      t.jSXExpressionContainer(css)
     )
   ]
 
@@ -427,9 +422,9 @@ export const makeStyledJsxTag = (id, transformedCss, expressions = []) => {
   }
 
   return t.jSXElement(
-    t.jSXOpeningElement(t.jSXIdentifier(STYLE_COMPONENT), attributes, true),
-    null,
-    []
+    t.jSXOpeningElement(t.jSXIdentifier(STYLE_COMPONENT), attributes),
+    t.jSXClosingElement(t.jSXIdentifier(STYLE_COMPONENT)),
+    [t.jSXExpressionContainer(css)]
   )
 }
 

--- a/src/style.js
+++ b/src/style.js
@@ -22,7 +22,7 @@ export default class JSXStyle extends Component {
   // probably faster than PureComponent (shallowEqual)
   shouldComponentUpdate(otherProps) {
     return (
-      this.props.styleId !== otherProps.styleId ||
+      this.props.id !== otherProps.id ||
       // We do this check because `dynamic` is an array of strings or undefined.
       // These are the computed values for dynamic styles.
       String(this.props.dynamic) !== String(otherProps.dynamic)
@@ -38,7 +38,7 @@ export default class JSXStyle extends Component {
     // See https://github.com/zeit/styled-jsx/pull/484
     if (this.shouldComponentUpdate(this.prevProps)) {
       // Updates
-      if (this.prevProps.styleId) {
+      if (this.prevProps.id) {
         styleSheetRegistry.remove(this.prevProps)
       }
       styleSheetRegistry.add(this.props)

--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -171,19 +171,21 @@ export default class StyleSheetRegistry {
   }
 
   getIdAndRules(props) {
-    if (props.dynamic) {
-      const styleId = this.computeId(props.styleId, props.dynamic)
+    const { children: css, dynamic, id } = props
+
+    if (dynamic) {
+      const styleId = this.computeId(id, dynamic)
       return {
         styleId,
-        rules: Array.isArray(props.css)
-          ? props.css.map(rule => this.computeSelector(styleId, rule))
-          : [this.computeSelector(styleId, props.css)]
+        rules: Array.isArray(css)
+          ? css.map(rule => this.computeSelector(styleId, rule))
+          : [this.computeSelector(styleId, css)]
       }
     }
 
     return {
-      styleId: this.computeId(props.styleId),
-      rules: Array.isArray(props.css) ? props.css : [props.css]
+      styleId: this.computeId(id),
+      rules: Array.isArray(css) ? css : [css]
     }
   }
 

--- a/test/__snapshots__/attribute.js.snap
+++ b/test/__snapshots__/attribute.js.snap
@@ -9,50 +9,50 @@ const styles2 = require('./styles2');
 // external only
 export const Test1 = () => <div className={\`jsx-\${styles.__hash} jsx-\${styles2.__hash}\`}>
     <p className={\`jsx-\${styles.__hash} jsx-\${styles2.__hash}\`}>external only</p>
-    <_JSXStyle styleId={styles.__hash} css={styles} />
-    <_JSXStyle styleId={styles2.__hash} css={styles2} />
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
+    <_JSXStyle id={styles2.__hash}>{styles2}</_JSXStyle>
   </div>;
 
 // external and static
 export const Test2 = () => <div className={'jsx-2982525546 ' + \`jsx-\${styles.__hash}\`}>
     <p className={'jsx-2982525546 ' + \`jsx-\${styles.__hash}\`}>external and static</p>
-    <_JSXStyle styleId={\\"2982525546\\"} css={\\"p.jsx-2982525546{color:red;}\\"} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={\\"2982525546\\"}>{\\"p.jsx-2982525546{color:red;}\\"}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>;
 
 // external and dynamic
 export const Test3 = ({ color }) => <div className={\`jsx-\${styles.__hash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>
     <p className={\`jsx-\${styles.__hash}\` + ' ' + _JSXStyle.dynamic([['1947484460', [color]]])}>external and dynamic</p>
-    <_JSXStyle styleId={\\"1947484460\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={\\"1947484460\\"} dynamic={[color]}>{\`p.__jsx-style-dynamic-selector{color:\${color};}\`}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>;
 
 // external, static and dynamic
 export const Test4 = ({ color }) => <div className={\`jsx-\${styles.__hash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
     <p className={\`jsx-\${styles.__hash}\` + ' jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>external, static and dynamic</p>
-    <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block;}\\"} />
-    <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={\\"3190985107\\"}>{\\"p.jsx-3190985107{display:inline-block;}\\"}</_JSXStyle>
+    <_JSXStyle id={\\"1336444426\\"} dynamic={[color]}>{\`p.__jsx-style-dynamic-selector{color:\${color};}\`}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>;
 
 // static only
 export const Test5 = () => <div className={\\"jsx-1372669040\\"}>
     <p className={\\"jsx-1372669040\\"}>static only</p>
-    <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-1372669040{display:inline-block;}\\"} />
-    <_JSXStyle styleId={\\"2982525546\\"} css={\\"p.jsx-1372669040{color:red;}\\"} />
+    <_JSXStyle id={\\"3190985107\\"}>{\\"p.jsx-1372669040{display:inline-block;}\\"}</_JSXStyle>
+    <_JSXStyle id={\\"2982525546\\"}>{\\"p.jsx-1372669040{color:red;}\\"}</_JSXStyle>
   </div>;
 
 // static and dynamic
 export const Test6 = ({ color }) => <div className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>
     <p className={'jsx-3190985107 ' + _JSXStyle.dynamic([['1336444426', [color]]])}>static and dynamic</p>
-    <_JSXStyle styleId={\\"3190985107\\"} css={\\"p.jsx-3190985107{display:inline-block;}\\"} />
-    <_JSXStyle styleId={\\"1336444426\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+    <_JSXStyle id={\\"3190985107\\"}>{\\"p.jsx-3190985107{display:inline-block;}\\"}</_JSXStyle>
+    <_JSXStyle id={\\"1336444426\\"} dynamic={[color]}>{\`p.__jsx-style-dynamic-selector{color:\${color};}\`}</_JSXStyle>
   </div>;
 
 // dynamic only
 export const Test7 = ({ color }) => <div className={_JSXStyle.dynamic([['1947484460', [color]]])}>
     <p className={_JSXStyle.dynamic([['1947484460', [color]]])}>dynamic only</p>
-    <_JSXStyle styleId={\\"1947484460\\"} css={\`p.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+    <_JSXStyle id={\\"1947484460\\"} dynamic={[color]}>{\`p.__jsx-style-dynamic-selector{color:\${color};}\`}</_JSXStyle>
   </div>;
 
 // dynamic with scoped compound variable
@@ -62,7 +62,7 @@ export const Test8 = ({ color }) => {
 
     return <div className={_JSXStyle.dynamic([['1791723528', [innerProps.color]]])}>
         <p className={_JSXStyle.dynamic([['1791723528', [innerProps.color]]])}>dynamic with scoped compound variable</p>
-        <_JSXStyle styleId={\\"1791723528\\"} css={\`p.__jsx-style-dynamic-selector{color:\${innerProps.color};}\`} dynamic={[innerProps.color]} />
+        <_JSXStyle id={\\"1791723528\\"} dynamic={[innerProps.color]}>{\`p.__jsx-style-dynamic-selector{color:\${innerProps.color};}\`}</_JSXStyle>
       </div>;
   }
 };
@@ -73,7 +73,7 @@ export const Test9 = ({ color }) => {
 
   return <div className={_JSXStyle.dynamic([['248922593', [innerProps.color]]])}>
       <p className={_JSXStyle.dynamic([['248922593', [innerProps.color]]])}>dynamic with compound variable</p>
-      <_JSXStyle styleId={\\"248922593\\"} css={\`p.__jsx-style-dynamic-selector{color:\${innerProps.color};}\`} dynamic={[innerProps.color]} />
+      <_JSXStyle id={\\"248922593\\"} dynamic={[innerProps.color]}>{\`p.__jsx-style-dynamic-selector{color:\${innerProps.color};}\`}</_JSXStyle>
     </div>;
 };
 
@@ -82,13 +82,13 @@ const foo = 'red';
 // dynamic with constant variable
 export const Test10 = () => <div className={\\"jsx-461505126\\"}>
     <p className={\\"jsx-461505126\\"}>dynamic with constant variable</p>
-    <_JSXStyle styleId={\\"461505126\\"} css={\`p.jsx-461505126{color:\${foo};}\`} />
+    <_JSXStyle id={\\"461505126\\"}>{\`p.jsx-461505126{color:\${foo};}\`}</_JSXStyle>
   </div>;
 
 // dynamic with complex scope
 export const Test11 = ({ color }) => {
   const items = Array.from({ length: 5 }).map((item, i) => <li key={i} className={_JSXStyle.dynamic([['2172653867', [color]]]) + ' ' + 'item'}>
-      <_JSXStyle styleId={\\"2172653867\\"} css={\`.item.__jsx-style-dynamic-selector{color:\${color};}\`} dynamic={[color]} />
+      <_JSXStyle id={\\"2172653867\\"} dynamic={[color]}>{\`.item.__jsx-style-dynamic-selector{color:\${color};}\`}</_JSXStyle>
       Item #{i + 1}
     </li>);
 
@@ -140,7 +140,7 @@ export default (() => {
       <Element className={\\"jsx-2886504620\\"} />
       <Element className={\\"jsx-2886504620\\" + \\" \\" + \\"test\\"} />
       <Element {...props} className={\\"jsx-2886504620\\" + \\" \\" + (props.className != null && props.className || \\"\\")} />
-      <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />
+      <_JSXStyle id={\\"2886504620\\"}>{\\"div.jsx-2886504620{color:red;}\\"}</_JSXStyle>
     </div>;
 });"
 `;

--- a/test/__snapshots__/external.js.snap
+++ b/test/__snapshots__/external.js.snap
@@ -29,24 +29,24 @@ export const foo = [\`div.jsx-2299908427{color:\${color};}\`];
 
 foo.__hash = '2299908427';
 ({
-  styles: <_JSXStyle styleId={\\"1329679275\\"} css={[\`div.jsx-1329679275{color:\${colors.green.light};}\`, 'a.jsx-1329679275{color:red;}']} />,
+  styles: <_JSXStyle id={\\"1329679275\\"}>{[\`div.jsx-1329679275{color:\${colors.green.light};}\`, 'a.jsx-1329679275{color:red;}']}</_JSXStyle>,
   className: 'jsx-1329679275'
 });
 
 const b = {
-  styles: <_JSXStyle styleId={\\"1329679275\\"} css={[\`div.jsx-1329679275{color:\${colors.green.light};}\`, 'a.jsx-1329679275{color:red;}']} />,
+  styles: <_JSXStyle id={\\"1329679275\\"}>{[\`div.jsx-1329679275{color:\${colors.green.light};}\`, 'a.jsx-1329679275{color:red;}']}</_JSXStyle>,
   className: 'jsx-1329679275'
 };
 
 const dynamic = colors => {
   const b = {
-    styles: <_JSXStyle styleId={\\"3325296745\\"} css={[\`div.__jsx-style-dynamic-selector{color:\${colors.green.light};}\`, 'a.__jsx-style-dynamic-selector{color:red;}']} dynamic={[colors.green.light]} />,
+    styles: <_JSXStyle id={\\"3325296745\\"} dynamic={[colors.green.light]}>{[\`div.__jsx-style-dynamic-selector{color:\${colors.green.light};}\`, 'a.__jsx-style-dynamic-selector{color:red;}']}</_JSXStyle>,
     className: _JSXStyle.dynamic([['3325296745', [colors.green.light]]])
   };
 };
 
 export default {
-  styles: <_JSXStyle styleId={\\"3290112549\\"} css={['div.jsx-3290112549{font-size:3em;}', \`p.jsx-3290112549{color:\${color};}\`]} />,
+  styles: <_JSXStyle id={\\"3290112549\\"}>{['div.jsx-3290112549{font-size:3em;}', \`p.jsx-3290112549{color:\${color};}\`]}</_JSXStyle>,
   className: 'jsx-3290112549'
 };"
 `;
@@ -62,7 +62,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function Test() {
   return <div>
-        <_style.default styleId={_App.default.__hash} css={_App.default} />
+        <_style.default id={_App.default.__hash}>{_App.default}</_style.default>
       </div>;
 }"
 `;
@@ -106,7 +106,7 @@ exports[`injects JSXStyle for nested scope 1`] = `
 
 function test() {
   ({
-    styles: <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />,
+    styles: <_JSXStyle id={\\"2886504620\\"}>{\\"div.jsx-2886504620{color:red;}\\"}</_JSXStyle>,
     className: 'jsx-2886504620'
   });
 }"
@@ -142,24 +142,24 @@ export const foo = new String(\`div.jsx-2299908427{color:\${color};}\`);
 
 foo.__hash = '2299908427';
 ({
-  styles: <_JSXStyle styleId={\\"1329679275\\"} css={\`div.jsx-1329679275{color:\${colors.green.light};}a.jsx-1329679275{color:red;}\`} />,
+  styles: <_JSXStyle id={\\"1329679275\\"}>{\`div.jsx-1329679275{color:\${colors.green.light};}a.jsx-1329679275{color:red;}\`}</_JSXStyle>,
   className: 'jsx-1329679275'
 });
 
 const b = {
-  styles: <_JSXStyle styleId={\\"1329679275\\"} css={\`div.jsx-1329679275{color:\${colors.green.light};}a.jsx-1329679275{color:red;}\`} />,
+  styles: <_JSXStyle id={\\"1329679275\\"}>{\`div.jsx-1329679275{color:\${colors.green.light};}a.jsx-1329679275{color:red;}\`}</_JSXStyle>,
   className: 'jsx-1329679275'
 };
 
 const dynamic = colors => {
   const b = {
-    styles: <_JSXStyle styleId={\\"3325296745\\"} css={\`div.__jsx-style-dynamic-selector{color:\${colors.green.light};}a.__jsx-style-dynamic-selector{color:red;}\`} dynamic={[colors.green.light]} />,
+    styles: <_JSXStyle id={\\"3325296745\\"} dynamic={[colors.green.light]}>{\`div.__jsx-style-dynamic-selector{color:\${colors.green.light};}a.__jsx-style-dynamic-selector{color:red;}\`}</_JSXStyle>,
     className: _JSXStyle.dynamic([['3325296745', [colors.green.light]]])
   };
 };
 
 export default {
-  styles: <_JSXStyle styleId={\\"3290112549\\"} css={\`div.jsx-3290112549{font-size:3em;}p.jsx-3290112549{color:\${color};}\`} />,
+  styles: <_JSXStyle id={\\"3290112549\\"}>{\`div.jsx-3290112549{font-size:3em;}p.jsx-3290112549{color:\${color};}\`}</_JSXStyle>,
   className: 'jsx-3290112549'
 };"
 `;
@@ -173,7 +173,7 @@ export default (({ level = 1 }) => {
 
   return <Element className={\`jsx-\${styles.__hash}\` + \\" \\" + \\"root\\"}>
       <p className={\`jsx-\${styles.__hash}\`}>dynamic element</p>
-      <_JSXStyle styleId={styles.__hash} css={styles} />
+      <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
     </Element>;
 });"
 `;
@@ -188,9 +188,9 @@ export default (() => <div>
     <p>test</p>
     <div>woot</div>
     <p>woot</p>
-    <_JSXStyle styleId={styles2.__hash} css={styles2} />
-    <_JSXStyle styleId={styles3.__hash} css={styles3} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={styles2.__hash}>{styles2}</_JSXStyle>
+    <_JSXStyle id={styles3.__hash}>{styles3}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>);"
 `;
 
@@ -200,7 +200,7 @@ import styles from './styles';
 
 export default (() => <div className={\`jsx-\${styles.__hash}\`}>
     <p className={\`jsx-\${styles.__hash}\`}>test</p>
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>);"
 `;
 
@@ -213,18 +213,18 @@ import { foo as styles3 } from './styles';
 export default (() => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\`}>
     <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\` + ' ' + 'foo'}>test</p>
     <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\`}>woot</p>
-    <_JSXStyle styleId={styles2.__hash} css={styles2} />
-    <_JSXStyle styleId={styles3.__hash} css={styles3} />
+    <_JSXStyle id={styles2.__hash}>{styles2}</_JSXStyle>
+    <_JSXStyle id={styles3.__hash}>{styles3}</_JSXStyle>
     <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash} jsx-\${styles.__hash}\`}>woot</div>
-    <_JSXStyle styleId={\\"1646697228\\"} css={\\"p.jsx-1646697228{color:red;}div.jsx-1646697228{color:green;}\\"} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={\\"1646697228\\"}>{\\"p.jsx-1646697228{color:red;}div.jsx-1646697228{color:green;}\\"}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>);
 
 export const Test = () => <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\`}>
     <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\` + ' ' + 'foo'}>test</p>
     <p className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\`}>woot</p>
-    <_JSXStyle styleId={styles3.__hash} css={styles3} />
+    <_JSXStyle id={styles3.__hash}>{styles3}</_JSXStyle>
     <div className={'jsx-1646697228 ' + \`jsx-\${styles3.__hash}\`}>woot</div>
-    <_JSXStyle styleId={\\"1646697228\\"} css={\\"p.jsx-1646697228{color:red;}div.jsx-1646697228{color:green;}\\"} />
+    <_JSXStyle id={\\"1646697228\\"}>{\\"p.jsx-1646697228{color:red;}div.jsx-1646697228{color:green;}\\"}</_JSXStyle>
   </div>;"
 `;

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`generates source maps 1`] = `
 export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFVBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"} />
+    <_JSXStyle id={\\"2743241663\\"}>{\\"p.jsx-2743241663{color:red;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXBzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlnQixBQUNjLFVBQUMiLCJmaWxlIjoic291cmNlLW1hcHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJleHBvcnQgZGVmYXVsdCAoKSA9PiAoXG4gIDxkaXY+XG4gICAgPHA+dGVzdDwvcD5cbiAgICA8cD53b290PC9wPlxuICAgIDxzdHlsZSBqc3g+eydwIHsgY29sb3I6IHJlZCB9J308L3N0eWxlPlxuICA8L2Rpdj5cbilcbiJdfQ== */\\\\n/*@ sourceURL=source-maps.js */\\"}</_JSXStyle>
   </div>);"
 `;
 
@@ -22,18 +22,18 @@ export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red;}\\"} />
+    <_JSXStyle id={\\"2743241663\\"}>{\\"p.jsx-2743241663{color:red;}\\"}</_JSXStyle>
   </div>);"
 `;
 
 exports[`mixed global and scoped 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
-const Test = () => <_JSXStyle styleId={\\"2743241663\\"} css={\\"p{color:red;}\\"} />;
+const Test = () => <_JSXStyle id={\\"2743241663\\"}>{\\"p{color:red;}\\"}</_JSXStyle>;
 
 export default (() => <div className={\\"jsx-2673076688\\"}>
     <p className={\\"jsx-2673076688\\"}>test</p>
-    <_JSXStyle styleId={\\"4269072806\\"} css={\\"body{background:red;}\\"} />
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2673076688{color:red;}\\"} />
+    <_JSXStyle id={\\"4269072806\\"}>{\\"body{background:red;}\\"}</_JSXStyle>
+    <_JSXStyle id={\\"2743241663\\"}>{\\"p.jsx-2673076688{color:red;}\\"}</_JSXStyle>
   </div>);"
 `;
 
@@ -44,12 +44,12 @@ const otherColor = 'green';
 
 const A = () => <div className={\\"jsx-57381496\\"}>
     <p className={\\"jsx-57381496\\"}>test</p>
-    <_JSXStyle styleId={\\"57381496\\"} css={\`p.jsx-57381496{color:\${color};}\`} />
+    <_JSXStyle id={\\"57381496\\"}>{\`p.jsx-57381496{color:\${color};}\`}</_JSXStyle>
   </div>;
 
 const B = () => <div className={\\"jsx-3099245642\\"}>
     <p className={\\"jsx-3099245642\\"}>test</p>
-    <_JSXStyle styleId={\\"3099245642\\"} css={\`p.jsx-3099245642{color:\${otherColor};}\`} />
+    <_JSXStyle id={\\"3099245642\\"}>{\`p.jsx-3099245642{color:\${otherColor};}\`}</_JSXStyle>
   </div>;
 
 export default (() => <div>
@@ -63,7 +63,7 @@ exports[`should not add the data-jsx attribute to components instances 1`] = `
 const Test = () => <div className={\\"jsx-2529315885\\"}>
     <span className={\\"jsx-2529315885\\"}>test</span>
     <Component />
-    <_JSXStyle styleId={\\"2529315885\\"} css={\\"span.jsx-2529315885{color:red;}\\"} />
+    <_JSXStyle id={\\"2529315885\\"}>{\\"span.jsx-2529315885{color:red;}\\"}</_JSXStyle>
   </div>;"
 `;
 
@@ -74,7 +74,7 @@ export default class {
   render() {
     return <div className={\\"jsx-2101845350\\"}>
         <p className={\\"jsx-2101845350\\"}>test</p>
-        <_JSXStyle styleId={\\"2101845350\\"} css={\\"p.jsx-2101845350{color:red;}\\"} />
+        <_JSXStyle id={\\"2101845350\\"}>{\\"p.jsx-2101845350{color:red;}\\"}</_JSXStyle>
       </div>;
   }
 
@@ -87,7 +87,7 @@ exports[`works with css tagged template literals in the same file 1`] = `
 
 export default (({ children }) => <div className={\`jsx-\${styles.__hash}\`}>
     <p className={\`jsx-\${styles.__hash}\`}>{children}</p>
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>);
 
 const styles = new String('p.jsx-2587355013{color:red;}');
@@ -97,7 +97,7 @@ class Test extends React.Component {
   render() {
     return <div className={\`jsx-\${styles.__hash}\`}>
         <p className={\`jsx-\${styles.__hash}\`}>{this.props.children}</p>
-        <_JSXStyle styleId={styles.__hash} css={styles} />
+        <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
       </div>;
   }
 }"
@@ -110,7 +110,7 @@ export default (({ level = 1 }) => {
 
   return <Element className={\\"jsx-1253978709\\" + \\" \\" + \\"root\\"}>
       <p className={\\"jsx-1253978709\\"}>dynamic element</p>
-      <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
+      <_JSXStyle id={\\"1253978709\\"}>{\\".root.jsx-1253978709{background:red;}\\"}</_JSXStyle>
     </Element>;
 });
 
@@ -119,7 +119,7 @@ export const TestLowerCase = ({ level = 1 }) => {
 
   return <element className={\\"jsx-1253978709\\" + \\" \\" + \\"root\\"}>
       <p className={\\"jsx-1253978709\\"}>dynamic element</p>
-      <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
+      <_JSXStyle id={\\"1253978709\\"}>{\\".root.jsx-1253978709{background:red;}\\"}</_JSXStyle>
     </element>;
 };
 
@@ -127,7 +127,7 @@ const Element2 = 'div';
 export const Test2 = () => {
   return <Element2 className=\\"root\\">
       <p className={\\"jsx-1253978709\\"}>dynamic element</p>
-      <_JSXStyle styleId={\\"1253978709\\"} css={\\".root.jsx-1253978709{background:red;}\\"} />
+      <_JSXStyle id={\\"1253978709\\"}>{\\".root.jsx-1253978709{background:red;}\\"}</_JSXStyle>
     </Element2>;
 };"
 `;
@@ -140,7 +140,7 @@ export default class {
 
     return <Element className={'jsx-1800172487' + ' ' + 'root'}>
         <p className={\\"jsx-1800172487\\"}>dynamic element</p>
-        <_JSXStyle styleId={\\"1800172487\\"} css={\\".root.jsx-1800172487{background:red;}\\"} />
+        <_JSXStyle id={\\"1800172487\\"}>{\\".root.jsx-1800172487{background:red;}\\"}</_JSXStyle>
       </Element>;
   }
 }
@@ -150,7 +150,7 @@ export const Test2 = class {
   render() {
     return <Element2 className=\\"root\\">
         <p className={\\"jsx-1800172487\\"}>dynamic element</p>
-        <_JSXStyle styleId={\\"1800172487\\"} css={\\".root.jsx-1800172487{background:red;}\\"} />
+        <_JSXStyle id={\\"1800172487\\"}>{\\".root.jsx-1800172487{background:red;}\\"}</_JSXStyle>
       </Element2>;
   }
 };"
@@ -168,29 +168,29 @@ const obj = { display: 'block' };
 
 export default (({ display }) => <div className={'jsx-3922596756 ' + _JSXStyle.dynamic([['1795062918', [display ? 'block' : 'none']]])}>
     <p className={'jsx-3922596756 ' + _JSXStyle.dynamic([['1795062918', [display ? 'block' : 'none']]])}>test</p>
-    <_JSXStyle styleId={\\"1003380713\\"} css={\`p.\${color}.jsx-3922596756{color:\${otherColor};display:\${obj.display};}\`} />
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-3922596756{color:red;}\\"} />
-    <_JSXStyle styleId={\\"602592955\\"} css={\`body{background:\${color};}\`} />
-    <_JSXStyle styleId={\\"602592955\\"} css={\`body{background:\${color};}\`} />
-    <_JSXStyle styleId={\\"128557999\\"} css={\`p.jsx-3922596756{color:\${color};}\`} />
-    <_JSXStyle styleId={\\"128557999\\"} css={\`p.jsx-3922596756{color:\${color};}\`} />
-    <_JSXStyle styleId={\\"2622100973\\"} css={\`p.jsx-3922596756{color:\${darken(color)};}\`} />
-    <_JSXStyle styleId={\\"1167419394\\"} css={\`p.jsx-3922596756{color:\${darken(color) + 2};}\`} />
-    <_JSXStyle styleId={\\"4052509549\\"} css={\`@media (min-width:\${mediumScreen}){p.jsx-3922596756{color:green;}p.jsx-3922596756{color:\${\`red\`};}}p.jsx-3922596756{color:red;}\`} />
-    <_JSXStyle styleId={\\"2824547816\\"} css={\`p.jsx-3922596756{-webkit-animation-duration:\${animationDuration};animation-duration:\${animationDuration};}\`} />
-    <_JSXStyle styleId={\\"417951176\\"} css={\`p.jsx-3922596756{-webkit-animation:\${animationDuration} forwards \${animationName};animation:\${animationDuration} forwards \${animationName};}div.jsx-3922596756{background:\${color};}\`} />
+    <_JSXStyle id={\\"1003380713\\"}>{\`p.\${color}.jsx-3922596756{color:\${otherColor};display:\${obj.display};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"2743241663\\"}>{\\"p.jsx-3922596756{color:red;}\\"}</_JSXStyle>
+    <_JSXStyle id={\\"602592955\\"}>{\`body{background:\${color};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"602592955\\"}>{\`body{background:\${color};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"128557999\\"}>{\`p.jsx-3922596756{color:\${color};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"128557999\\"}>{\`p.jsx-3922596756{color:\${color};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"2622100973\\"}>{\`p.jsx-3922596756{color:\${darken(color)};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"1167419394\\"}>{\`p.jsx-3922596756{color:\${darken(color) + 2};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"4052509549\\"}>{\`@media (min-width:\${mediumScreen}){p.jsx-3922596756{color:green;}p.jsx-3922596756{color:\${\`red\`};}}p.jsx-3922596756{color:red;}\`}</_JSXStyle>
+    <_JSXStyle id={\\"2824547816\\"}>{\`p.jsx-3922596756{-webkit-animation-duration:\${animationDuration};animation-duration:\${animationDuration};}\`}</_JSXStyle>
+    <_JSXStyle id={\\"417951176\\"}>{\`p.jsx-3922596756{-webkit-animation:\${animationDuration} forwards \${animationName};animation:\${animationDuration} forwards \${animationName};}div.jsx-3922596756{background:\${color};}\`}</_JSXStyle>
 
-    <_JSXStyle styleId={\\"1795062918\\"} css={\`span.__jsx-style-dynamic-selector{display:\${display ? 'block' : 'none'};}\`} dynamic={[display ? 'block' : 'none']} />
+    <_JSXStyle id={\\"1795062918\\"} dynamic={[display ? 'block' : 'none']}>{\`span.__jsx-style-dynamic-selector{display:\${display ? 'block' : 'none'};}\`}</_JSXStyle>
   </div>);"
 `;
 
 exports[`works with global styles 1`] = `
 "import _JSXStyle from 'styled-jsx/style';
 const Test = () => <div className={\\"jsx-2209073070\\"}>
-    <_JSXStyle styleId={\\"2209073070\\"} css={\\"body{color:red;}:hover{color:red;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-animation:foo 1s ease-out;animation:foo 1s ease-out;}div a{display:none;}[data-test]>div{color:red;}\\"} />
+    <_JSXStyle id={\\"2209073070\\"}>{\\"body{color:red;}:hover{color:red;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-animation:foo 1s ease-out;animation:foo 1s ease-out;}div a{display:none;}[data-test]>div{color:red;}\\"}</_JSXStyle>
   </div>;
 
-const Test2 = () => <_JSXStyle styleId={\\"2743241663\\"} css={\\"p{color:red;}\\"} />;"
+const Test2 = () => <_JSXStyle id={\\"2743241663\\"}>{\\"p{color:red;}\\"}</_JSXStyle>;"
 `;
 
 exports[`works with multiple jsx blocks 1`] = `
@@ -202,21 +202,21 @@ const attrs = {
 const Test1 = () => <div className={\\"jsx-2529315885\\"}>
     <span {...attrs} data-test=\\"test\\" className={\\"jsx-2529315885\\" + \\" \\" + (attrs.className != null && attrs.className || \\"\\")}>test</span>
     <Component />
-    <_JSXStyle styleId={\\"2529315885\\"} css={\\"span.jsx-2529315885{color:red;}\\"} />
+    <_JSXStyle id={\\"2529315885\\"}>{\\"span.jsx-2529315885{color:red;}\\"}</_JSXStyle>
   </div>;
 
 const Test2 = () => <span>test</span>;
 
 const Test3 = () => <div className={\\"jsx-2529315885\\"}>
     <span className={\\"jsx-2529315885\\"}>test</span>
-    <_JSXStyle styleId={\\"2529315885\\"} css={\\"span.jsx-2529315885{color:red;}\\"} />
+    <_JSXStyle id={\\"2529315885\\"}>{\\"span.jsx-2529315885{color:red;}\\"}</_JSXStyle>
   </div>;
 
 export default class {
   render() {
     return <div className={\\"jsx-2101845350\\"}>
         <p className={\\"jsx-2101845350\\"}>test</p>
-        <_JSXStyle styleId={\\"2101845350\\"} css={\\"p.jsx-2101845350{color:red;}\\"} />
+        <_JSXStyle id={\\"2101845350\\"}>{\\"p.jsx-2101845350{color:red;}\\"}</_JSXStyle>
       </div>;
   }
 }"
@@ -227,7 +227,7 @@ exports[`works with non styled-jsx styles 1`] = `
 export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>woot</p>
     <style dangerouslySetInnerHTML={{ __html: \`body { margin: 0; }\` }}></style>
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red;}\\"} />
+    <_JSXStyle id={\\"2743241663\\"}>{\\"p.jsx-2743241663{color:red;}\\"}</_JSXStyle>
   </div>);"
 `;
 
@@ -237,6 +237,6 @@ export default (() => <div className={\\"jsx-2743241663\\"}>
     <p className={\\"jsx-2743241663\\"}>test</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
     <p className={\\"jsx-2743241663\\"}>woot</p>
-    <_JSXStyle styleId={\\"2743241663\\"} css={\\"p.jsx-2743241663{color:red;}\\"} />
+    <_JSXStyle id={\\"2743241663\\"}>{\\"p.jsx-2743241663{color:red;}\\"}</_JSXStyle>
   </div>);"
 `;

--- a/test/__snapshots__/macro.js.snap
+++ b/test/__snapshots__/macro.js.snap
@@ -5,7 +5,7 @@ exports[`can alias the named import 1`] = `
 
 
 ({
-    styles: <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />,
+    styles: <_JSXStyle id={\\"2886504620\\"}>{\\"div.jsx-2886504620{color:red;}\\"}</_JSXStyle>,
     className: 'jsx-2886504620'
 });"
 `;
@@ -16,7 +16,7 @@ exports[`injects JSXStyle for nested scope 1`] = `
 
 function test() {
   ({
-    styles: <_JSXStyle styleId={\\"2886504620\\"} css={\\"div.jsx-2886504620{color:red;}\\"} />,
+    styles: <_JSXStyle id={\\"2886504620\\"}>{\\"div.jsx-2886504620{color:red;}\\"}</_JSXStyle>,
     className: 'jsx-2886504620'
   });
 }"
@@ -27,22 +27,22 @@ exports[`transpiles correctly 1`] = `
 
 
 const { className, styles } = {
-  styles: <_JSXStyle styleId={\\"2052294191\\"} css={\\"div.jsx-2052294191{color:red;}\\"} />,
+  styles: <_JSXStyle id={\\"2052294191\\"}>{\\"div.jsx-2052294191{color:red;}\\"}</_JSXStyle>,
   className: 'jsx-2052294191'
 };
 
 const dynamicStyles = props => ({
-  styles: <_JSXStyle styleId={\\"290194820\\"} css={\`div.__jsx-style-dynamic-selector{color:\${props.color};}\`} dynamic={[props.color]} />,
+  styles: <_JSXStyle id={\\"290194820\\"} dynamic={[props.color]}>{\`div.__jsx-style-dynamic-selector{color:\${props.color};}\`}</_JSXStyle>,
   className: _JSXStyle.dynamic([['290194820', [props.color]]])
 });
 
 const test = {
-  styles: <_JSXStyle styleId={\\"2052294191\\"} css={\\"div.jsx-2052294191{color:red;}\\"} />,
+  styles: <_JSXStyle id={\\"2052294191\\"}>{\\"div.jsx-2052294191{color:red;}\\"}</_JSXStyle>,
   className: 'jsx-2052294191'
 };
 
 const dynamicStyles2 = props => ({
-  styles: <_JSXStyle styleId={\\"290194820\\"} css={\`div.__jsx-style-dynamic-selector{color:\${props.color};}\`} dynamic={[props.color]} />,
+  styles: <_JSXStyle id={\\"290194820\\"} dynamic={[props.color]}>{\`div.__jsx-style-dynamic-selector{color:\${props.color};}\`}</_JSXStyle>,
   className: _JSXStyle.dynamic([['290194820', [props.color]]])
 });
 

--- a/test/__snapshots__/plugins.js.snap
+++ b/test/__snapshots__/plugins.js.snap
@@ -7,8 +7,8 @@ const color = 'red';
 
 export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>
     <p className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>test</p>
-    <_JSXStyle styleId={\\"3382438999\\"} css={\`span.\${color}.jsx-3382438999{color:\${otherColor};}\`} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={\\"3382438999\\"}>{\`span.\${color}.jsx-3382438999{color:\${otherColor};}\`}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>);"
 `;
 
@@ -34,7 +34,7 @@ const color = 'red';
 
 export default (() => <div className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>
     <p className={'jsx-3382438999 ' + \`jsx-\${styles.__hash}\`}>test</p>
-    <_JSXStyle styleId={\\"3382438999\\"} css={\\".test.jsx-3382438999{content:\\\\\\"{\\\\\\"foo\\\\\\":false,\\\\\\"babel\\\\\\":{\\\\\\"location\\\\\\":{\\\\\\"start\\\\\\":{\\\\\\"line\\\\\\":7,\\\\\\"column\\\\\\":16},\\\\\\"end\\\\\\":{\\\\\\"line\\\\\\":11,\\\\\\"column\\\\\\":5}},\\\\\\"vendorPrefixes\\\\\\":false,\\\\\\"sourceMaps\\\\\\":false,\\\\\\"isGlobal\\\\\\":false}}\\\\\\";}\\"} />
-    <_JSXStyle styleId={styles.__hash} css={styles} />
+    <_JSXStyle id={\\"3382438999\\"}>{\\".test.jsx-3382438999{content:\\\\\\"{\\\\\\"foo\\\\\\":false,\\\\\\"babel\\\\\\":{\\\\\\"location\\\\\\":{\\\\\\"start\\\\\\":{\\\\\\"line\\\\\\":7,\\\\\\"column\\\\\\":16},\\\\\\"end\\\\\\":{\\\\\\"line\\\\\\":11,\\\\\\"column\\\\\\":5}},\\\\\\"vendorPrefixes\\\\\\":false,\\\\\\"sourceMaps\\\\\\":false,\\\\\\"isGlobal\\\\\\":false}}\\\\\\";}\\"}</_JSXStyle>
+    <_JSXStyle id={styles.__hash}>{styles}</_JSXStyle>
   </div>);"
 `;

--- a/test/index.js
+++ b/test/index.js
@@ -105,18 +105,27 @@ test('server rendering', t => {
     return React.createElement(
       'div',
       null,
-      React.createElement(JSXStyle, {
-        css: 'p { color: red }',
-        styleId: 1
-      }),
-      React.createElement(JSXStyle, {
-        css: 'div { color: blue }',
-        styleId: 2
-      }),
-      React.createElement(JSXStyle, {
-        css: `div { color: ${color} }`,
-        styleId: 3
-      })
+      React.createElement(
+        JSXStyle,
+        {
+          id: 1
+        },
+        'p { color: red }'
+      ),
+      React.createElement(
+        JSXStyle,
+        {
+          id: 2
+        },
+        'div { color: blue }'
+      ),
+      React.createElement(
+        JSXStyle,
+        {
+          id: 3
+        },
+        `div { color: ${color} }`
+      )
     )
   }
   // Expected CSS
@@ -152,18 +161,27 @@ test('server rendering with nonce', t => {
     return React.createElement(
       'div',
       null,
-      React.createElement(JSXStyle, {
-        css: 'p { color: red }',
-        styleId: 1
-      }),
-      React.createElement(JSXStyle, {
-        css: 'div { color: blue }',
-        styleId: 2
-      }),
-      React.createElement(JSXStyle, {
-        css: `div { color: ${color} }`,
-        styleId: 3
-      })
+      React.createElement(
+        JSXStyle,
+        {
+          id: 1
+        },
+        'p { color: red }'
+      ),
+      React.createElement(
+        JSXStyle,
+        {
+          id: 2
+        },
+        'div { color: blue }'
+      ),
+      React.createElement(
+        JSXStyle,
+        {
+          id: 3
+        },
+        `div { color: ${color} }`
+      )
     )
   }
   // Expected CSS

--- a/test/stylesheet-registry.js
+++ b/test/stylesheet-registry.js
@@ -33,8 +33,8 @@ test(
     options.forEach(options => {
       const registry = makeRegistry(options)
       registry.add({
-        styleId: '123',
-        css: options.optimizeForSpeed ? [cssRule] : cssRule
+        id: '123',
+        children: options.optimizeForSpeed ? [cssRule] : cssRule
       })
 
       t.deepEqual(registry.cssRules(), [['jsx-123', cssRule]])
@@ -42,15 +42,15 @@ test(
       // Dedupe
 
       registry.add({
-        styleId: '123',
-        css: options.optimizeForSpeed ? [cssRule] : cssRule
+        id: '123',
+        children: options.optimizeForSpeed ? [cssRule] : cssRule
       })
 
       t.deepEqual(registry.cssRules(), [['jsx-123', cssRule]])
 
       registry.add({
-        styleId: '345',
-        css: options.optimizeForSpeed ? [cssRule] : cssRule
+        id: '345',
+        children: options.optimizeForSpeed ? [cssRule] : cssRule
       })
 
       t.deepEqual(registry.cssRules(), [
@@ -59,7 +59,7 @@ test(
       ])
 
       if (options.optimizeForSpeed) {
-        registry.add({ styleId: '456', css: [cssRule, cssRuleAlt] })
+        registry.add({ id: '456', children: [cssRule, cssRuleAlt] })
 
         t.deepEqual(registry.cssRules(), [
           ['jsx-123', cssRule],
@@ -77,13 +77,13 @@ test(
     const registry = makeRegistry()
 
     // Insert a valid rule
-    registry.add({ styleId: '123', css: [cssRule] })
+    registry.add({ id: '123', children: [cssRule] })
 
     // Insert an invalid rule
-    registry.add({ styleId: '456', css: [invalidRules[0]] })
+    registry.add({ id: '456', children: [invalidRules[0]] })
 
     // Insert another valid rule
-    registry.add({ styleId: '678', css: [cssRule] })
+    registry.add({ id: '678', children: [cssRule] })
 
     t.deepEqual(registry.cssRules(), [
       ['jsx-123', 'div { color: red }'],
@@ -98,11 +98,11 @@ test(
     const registry = makeRegistry()
 
     // Insert a valid rule
-    registry.add({ styleId: '123', css: [cssRule] })
+    registry.add({ id: '123', children: [cssRule] })
 
     t.notThrows(() => {
       // Insert an invalid rule
-      registry.add({ styleId: '456', css: [invalidRules[0]] })
+      registry.add({ id: '456', children: [invalidRules[0]] })
     })
 
     t.deepEqual(registry.cssRules(), [['jsx-123', 'div { color: red }']])
@@ -113,8 +113,8 @@ test('add - sanitizes dynamic CSS on the server', t => {
   const registry = makeRegistry({ optimizeForSpeed: false, isBrowser: false })
 
   registry.add({
-    styleId: '123',
-    css: [
+    id: '123',
+    children: [
       'div.__jsx-style-dynamic-selector { color: red</style><script>alert("howdy")</script> }'
     ],
     dynamic: ['red</style><script>alert("howdy")</script>']
@@ -144,7 +144,7 @@ test('add - nonce is properly fetched from meta tag', t => {
   }
 
   const registry = makeRegistry()
-  registry.add({ styleId: '123', css: [cssRule] })
+  registry.add({ id: '123', children: [cssRule] })
 
   t.is(registry._sheet._nonce, 'test-nonce')
 
@@ -166,29 +166,29 @@ test(
     options.forEach(options => {
       const registry = makeRegistry(options)
       registry.add({
-        styleId: '123',
-        css: options.optimizeForSpeed ? [cssRule] : cssRule
+        id: '123',
+        children: options.optimizeForSpeed ? [cssRule] : cssRule
       })
 
       registry.add({
-        styleId: '345',
-        css: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
+        id: '345',
+        children: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
       })
 
-      registry.remove({ styleId: '123' })
+      registry.remove({ id: '123' })
       t.deepEqual(registry.cssRules(), [['jsx-345', cssRuleAlt]])
 
       // Add a duplicate
       registry.add({
-        styleId: '345',
-        css: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
+        id: '345',
+        children: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
       })
       // and remove it
-      registry.remove({ styleId: '345' })
+      registry.remove({ id: '345' })
       // Still in the registry
       t.deepEqual(registry.cssRules(), [['jsx-345', cssRuleAlt]])
       // remove again
-      registry.remove({ styleId: '345' })
+      registry.remove({ id: '345' })
       // now the registry should be empty
       t.deepEqual(registry.cssRules(), [])
     })
@@ -210,20 +210,20 @@ test(
     options.forEach(options => {
       const registry = makeRegistry(options)
       registry.add({
-        styleId: '123',
-        css: options.optimizeForSpeed ? [cssRule] : cssRule
+        id: '123',
+        children: options.optimizeForSpeed ? [cssRule] : cssRule
       })
 
       registry.add({
-        styleId: '123',
-        css: options.optimizeForSpeed ? [cssRule] : cssRule
+        id: '123',
+        children: options.optimizeForSpeed ? [cssRule] : cssRule
       })
 
       registry.update(
-        { styleId: '123' },
+        { id: '123' },
         {
-          styleId: '345',
-          css: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
+          id: '345',
+          children: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
         }
       )
       // Doesn't remove when there are multiple instances of 123
@@ -232,15 +232,15 @@ test(
         ['jsx-345', cssRuleAlt]
       ])
 
-      registry.remove({ styleId: '345' })
+      registry.remove({ id: '345' })
       t.deepEqual(registry.cssRules(), [['jsx-123', cssRule]])
 
       // Update again
       registry.update(
-        { styleId: '123' },
+        { id: '123' },
         {
-          styleId: '345',
-          css: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
+          id: '345',
+          children: options.optimizeForSpeed ? [cssRuleAlt] : cssRuleAlt
         }
       )
       // 123 replaced with 345
@@ -294,8 +294,8 @@ test(
     // simple
     t.deepEqual(
       utilRegistry.getIdAndRules({
-        styleId: '123',
-        css: '.test {} .jsx-123 { color: red } .jsx-123 { color: red }'
+        id: '123',
+        children: '.test {} .jsx-123 { color: red } .jsx-123 { color: red }'
       }),
       {
         styleId: 'jsx-123',
@@ -306,8 +306,8 @@ test(
     // dynamic
     t.deepEqual(
       utilRegistry.getIdAndRules({
-        styleId: '123',
-        css:
+        id: '123',
+        children:
           '.test {} .__jsx-style-dynamic-selector { color: red } .__jsx-style-dynamic-selector { color: red }',
         dynamic: ['test', 3, 'test']
       }),
@@ -322,8 +322,8 @@ test(
     // dynamic, css array
     t.deepEqual(
       utilRegistry.getIdAndRules({
-        styleId: '123',
-        css: [
+        id: '123',
+        children: [
           '.test {}',
           '.__jsx-style-dynamic-selector { color: red }',
           '.__jsx-style-dynamic-selector { color: red }'


### PR DESCRIPTION
Updating JSXStyle generated prop names to a shorter version:
* `styleId` - > `id`
* `css` -> leveraging JSX's `children` (the css content will be enclosed into `<JSXStyle></JSXStyle>` element.

Transpiled version  changes from:
```javascript
// ...
React.createElement(JSXStyle, {
    styleId: "3463673021",
    css: ".test.jsx-3463673021{color:red;}"
});
// ...
```
to:
```javascript
// ...
React.createElement(JSXStyle, {
    id: "3463673021"
}, ".test.jsx-3463673021{color:red;}");
// ....
```

While it helps reduce the final bundle size, it also resolves the incompatibility issue with styled-components ([details](https://github.com/zeit/styled-jsx/issues/530#issuecomment-446841545))