### PR TITLE
Remove line breaks from production styles

### DIFF
--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -33,7 +33,7 @@ export default class StyleSheetRegistry {
 
   add(props) {
     if (undefined === this._optimizeForSpeed) {
-      this._optimizeForSpeed = Array.isArray(props.css)
+      this._optimizeForSpeed = Array.isArray(props.children)
       this._sheet.setOptimizeForSpeed(this._optimizeForSpeed)
       this._optimizeForSpeed = this._sheet.isOptimizeForSpeed()
     }
@@ -118,7 +118,7 @@ export default class StyleSheetRegistry {
           styleId,
           this._indices[styleId]
             .map(index => cssRules[index].cssText)
-            .join('\n')
+            .join(this._optimizeForSpeed ? '' : '\n')
         ])
         // filter out empty rules
         .filter(rule => Boolean(rule[1]))

--- a/test/babel6/stylesheet-registry.js
+++ b/test/babel6/stylesheet-registry.js
@@ -64,7 +64,7 @@ test(
         t.deepEqual(registry.cssRules(), [
           ['jsx-123', cssRule],
           ['jsx-345', cssRule],
-          ['jsx-456', 'div { color: red }\np { color: red }']
+          ['jsx-456', 'div { color: red }p { color: red }']
         ])
       }
     })

--- a/test/stylesheet-registry.js
+++ b/test/stylesheet-registry.js
@@ -64,7 +64,7 @@ test(
         t.deepEqual(registry.cssRules(), [
           ['jsx-123', cssRule],
           ['jsx-345', cssRule],
-          ['jsx-456', 'div { color: red }\np { color: red }']
+          ['jsx-456', 'div { color: red }p { color: red }']
         ])
       }
     })


### PR DESCRIPTION
Fixes https://spectrum.chat/?t=b97a01eb-5e2c-47ac-9f4c-c05a71afd456

Also fixes a regression introduced in #534 where a prop was not renamed to `children`.