### PR TITLE
Remove singleton references to StylesheetRegistry.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,15 @@
 import React from 'react'
-import { flush } from './style'
+import StylesheetRegistryContext from './stylesheet-registry-context'
+import StylesheetRegistry from './stylesheet-registry'
 
-export default function flushToReact(options = {}) {
-  return flush().map(args => {
+function flush(styleSheetRegistry) {
+  const cssRules = styleSheetRegistry.cssRules()
+  styleSheetRegistry.flush()
+  return cssRules
+}
+
+export default function flushToReact(registry, options = {}) {
+  return flush(registry).map(args => {
     const id = args[0]
     const css = args[1]
     return React.createElement('style', {
@@ -17,8 +24,8 @@ export default function flushToReact(options = {}) {
   })
 }
 
-export function flushToHTML(options = {}) {
-  return flush().reduce((html, args) => {
+export function flushToHTML(registry, options = {}) {
+  return flush(registry).reduce((html, args) => {
     const id = args[0]
     const css = args[1]
     html += `<style id="__${id}"${
@@ -26,4 +33,55 @@ export function flushToHTML(options = {}) {
     }>${css}</style>`
     return html
   }, '')
+}
+
+export function wrapWithProvider(element, registry) {
+  return React.createElement(
+    StylesheetRegistryContext.Provider,
+    { value: registry },
+    element
+  )
+}
+
+export function callDomServerMethod(reactDomServer, method, element) {
+  const registry = new StylesheetRegistry()
+  const wrapped = wrapWithProvider(element, registry)
+  const result = reactDomServer[method](wrapped)
+  return { result, registry }
+}
+
+export function renderToString(server, element) {
+  return callDomServerMethod(server, 'renderToString', element)
+}
+
+export function renderToStaticMarkup(server, element) {
+  return callDomServerMethod(server, 'renderToStaticMarkup', element)
+}
+
+export function renderToNodeStream(server, element) {
+  return callDomServerMethod(server, 'renderToNodeStream', element)
+}
+
+export function renderToStaticNodeStream(server, element) {
+  return callDomServerMethod(server, 'renderToStaticNodeStream', element)
+}
+
+export function wrapServer(server) {
+  return {
+    renderToString(element) {
+      return renderToString(server, element)
+    },
+
+    renderToStaticMarkup(element) {
+      return renderToStaticMarkup(server, element)
+    },
+
+    renderToNodeStream(element) {
+      renderToNodeStream(server, element)
+    },
+
+    renderToStaticNodeStream(element) {
+      renderToStaticNodeStream(server, element)
+    }
+  }
 }

--- a/src/style.js
+++ b/src/style.js
@@ -1,7 +1,5 @@
 import { Component } from 'react'
-import StyleSheetRegistry from './stylesheet-registry'
-
-const styleSheetRegistry = new StyleSheetRegistry()
+import RegistryContext from './stylesheet-registry-context'
 
 export default class JSXStyle extends Component {
   constructor(props) {
@@ -9,7 +7,7 @@ export default class JSXStyle extends Component {
     this.prevProps = {}
   }
 
-  static dynamic(info) {
+  /* static dynamic(info) {
     return info
       .map(tagInfo => {
         const baseId = tagInfo[0]
@@ -17,7 +15,7 @@ export default class JSXStyle extends Component {
         return styleSheetRegistry.computeId(baseId, props)
       })
       .join(' ')
-  }
+  } */
 
   // probably faster than PureComponent (shallowEqual)
   shouldComponentUpdate(otherProps) {
@@ -30,7 +28,7 @@ export default class JSXStyle extends Component {
   }
 
   componentWillUnmount() {
-    styleSheetRegistry.remove(this.props)
+    this.context.remove(this.props)
   }
 
   render() {
@@ -39,10 +37,10 @@ export default class JSXStyle extends Component {
     if (this.shouldComponentUpdate(this.prevProps)) {
       // Updates
       if (this.prevProps.id) {
-        styleSheetRegistry.remove(this.prevProps)
+        this.context.remove(this.prevProps)
       }
 
-      styleSheetRegistry.add(this.props)
+      this.context.add(this.props)
       this.prevProps = this.props
     }
 
@@ -50,8 +48,4 @@ export default class JSXStyle extends Component {
   }
 }
 
-export function flush() {
-  const cssRules = styleSheetRegistry.cssRules()
-  styleSheetRegistry.flush()
-  return cssRules
-}
+JSXStyle.contextType = RegistryContext

--- a/src/stylesheet-registry-context.js
+++ b/src/stylesheet-registry-context.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+const defaultInstance = {}
+
+const methods = [
+  'add',
+  'remove',
+  'update',
+  'flush',
+  'cssRules',
+  'createComputeId',
+  'createComputeSelector',
+  'getIdAndRules',
+  'selectFromServer'
+]
+
+methods.forEach(methodName => {
+  defaultInstance[methodName] = () => {
+    throw new Error(
+      `StylesheetRegistry.${methodName}: The style registry can no longer be referenced statically. You must wrap each render with a StyleSheetRegistryContext.Provider, and provide a unique registry for each render`
+    )
+  }
+})
+
+const StyleSheetRegistryContext = React.createContext(defaultInstance)
+
+export default StyleSheetRegistryContext


### PR DESCRIPTION
Apps must wrap with a StylesheetRegistryContext.Provider

Fixes #64 

There is definitely work left to be done before this can be merged, including documentation and probably some discussion of the API.

Most importantly, this introduces a number of breaking changes to the API:

  * `server.js`: `flushToReact()` and `flushToHtml()` both now require an instance of `StylesheetRegistry` as their first argument.
  * `style.js`: The `flush` function was removed. It was a static export.
  * `style.js`: The static class function `JSXStyle.dynamic(info)` was removed. It is not covered by tests, nor used anywhere in the project.
  * I introduced a whole bunch of helper functions in `server.js`. Most of them serve to wrap the API of [ReactDomServer](https://reactjs.org/docs/react-dom-server.html#overview). The wrapped functions return an object containing both the `result` of the called function (i.e. `renderToString`, `renderToStaticMarkup`, etc), and a new `StylesheetRegistry` that was passed to the render.
  * This makes use of `React.createContext`, so requires `React@16.3` or higher. If that is a problem, I can try to add support for the legacy API, but it's deprecated and will be removed.

TODO:

- [ ] Maintainers accept proposed API.
- [ ] Update documentation, especially SSR examples.
- [ ] PR to Next.js, which is broken by this change.