### PR TITLE
CSSRulesList in browser environments is not actually an array.

### DIFF
--- a/src/lib/stylesheet.js
+++ b/src/lib/stylesheet.js
@@ -216,7 +216,7 @@ export default class StyleSheet {
     return this._tags.reduce((rules, tag) => {
       if (tag) {
         rules = rules.concat(
-          this.getSheetForTag(tag).cssRules.map(rule =>
+          Array.from(this.getSheetForTag(tag).cssRules).map(rule =>
             rule.cssText === this._deletedRulePlaceholder ? null : rule
           )
         )

--- a/src/lib/stylesheet.js
+++ b/src/lib/stylesheet.js
@@ -216,7 +216,7 @@ export default class StyleSheet {
     return this._tags.reduce((rules, tag) => {
       if (tag) {
         rules = rules.concat(
-          Array.from(this.getSheetForTag(tag).cssRules).map(rule =>
+          Array.prototype.map.call(this.getSheetForTag(tag).cssRules, rule =>
             rule.cssText === this._deletedRulePlaceholder ? null : rule
           )
         )


### PR DESCRIPTION
Therefore it doesn't have a `map` function.
As a result, calling flush on browser environment fails.

This fixes the issue by converting it to an array using Array.from