### PR TITLE
Switch to loose mode

### DIFF
--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,4 +1,8 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": ["@babel/plugin-proposal-object-rest-spread"]
+  "presets": [
+    ["@babel/preset-env", { "loose": true }]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-object-rest-spread", { "loose": true }
+  ]
 }

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -3,6 +3,6 @@
     ["@babel/preset-env", { "loose": true }]
   ],
   "plugins": [
-    ["@babel/plugin-proposal-object-rest-spread", { "loose": true }
+    ["@babel/plugin-proposal-object-rest-spread", { "loose": true }]
   ]
 }

--- a/src/babel.js
+++ b/src/babel.js
@@ -159,7 +159,7 @@ export default function({ types: t }) {
             externalJsxId = t.templateLiteral(
               [
                 t.templateElement({ raw: 'jsx-', cooked: 'jsx-' }),
-                ...[...new Array(expressionsLength - 1)].map(() =>
+                ...[...new Array(expressionsLength - 1).fill(null)].map(() =>
                   t.templateElement({ raw: ' jsx-', cooked: ' jsx-' })
                 ),
                 t.templateElement({ raw: '', cooked: '' }, true)


### PR DESCRIPTION
`styled-jsx` doesn't use any syntax that requires non-loose mode, and isn't using "spec" mode in the first place. Non-loose non-spec mode is verbose but doesn't adhere to the spec, so there's seldom a reason to use it.

This should reduce the size of styled-jsx considerably.