### PR TITLE
Escape filename in generated source map code.

### DIFF
--- a/src/_utils.js
+++ b/src/_utils.js
@@ -476,7 +476,7 @@ export const makeSourceMapGenerator = file => {
 export const addSourceMaps = (code, generator, filename) => {
   const sourceMaps = [
     convert.fromObject(generator).toComment({ multiline: true }),
-    `/*@ sourceURL=${filename} */`
+    `/*@ sourceURL=${filename.replace(/\\/g, '\\\\')} */`
   ]
 
   if (Array.isArray(code)) {


### PR DESCRIPTION
Currently on windows `sourceURL`s for source maps are broken and if the path includes a file or folder that starts with "u" or "x" followed by an incorrect escape sequence the produced code fails to compile.

This replaces all instances of "\" inside the string with "\\" resulting in properly escaped backslashes.

Issue on next.js repo: https://github.com/zeit/next.js/issues/9065