### PR TITLE
Docs: Fix typo.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -629,13 +629,15 @@ import styles from './styles.css?type=global'
 config: {
   module: {
     rules: [
-      test: /\.css$/,
-      use: [{
-        loader: require('styled-jsx/webpack').loader,
-        options: {
-          type: (fileName, options) => options.query.type || 'scoped'
-        }
-      }]
+      {
+        test: /\.css$/,
+        use: [{
+          loader: require('styled-jsx/webpack').loader,
+          options: {
+            type: 'scoped'
+          }
+        }]
+      }
     ]
   }
 }


### PR DESCRIPTION
The webpack config example in the "Styles in regular CSS files" was missing an opening brace in the `rules` array