### PR TITLE
Docs: Fix multiple typos.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -601,13 +601,15 @@ To use this feature you need to register the loader in your webpack config file,
 config: {
   module: {
     rules: [
-      test: /\.css$/,
-      use: [{
-        loader: require('styled-jsx/webpack').loader,
-        options: {
-          type: 'scoped'
-        }
-      }]
+      {
+        test: /\.css$/,
+        use: [{
+          loader: require('styled-jsx/webpack').loader,
+          options: {
+            type: 'scoped'
+          }
+        }]
+      }
     ]
   }
 }
@@ -634,7 +636,7 @@ config: {
         use: [{
           loader: require('styled-jsx/webpack').loader,
           options: {
-            type: 'scoped'
+            type: (fileName, options) => options.query.type || 'scoped'
           }
         }]
       }


### PR DESCRIPTION
In PR #599, I fixed the wrong typo. I didn't realize both config examples were missing opening brackets and accidentally fixed the second config example, but using the `options` from the first example.

Both typos have now been fixed, as well as, restoring their respective `options` objects to the correct version. Sorry for the screwup!