### PR TITLE
Rename ZEIT to Vercel

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-present Zeit, Inc.
+Copyright (c) 2016-present Vercel, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   },
   "keywords": [
     "babel-plugin-macros",
+    "vercel",
     "zeit",
     "css-in-js",
     "css"

--- a/readme.md
+++ b/readme.md
@@ -1013,6 +1013,6 @@ If you're using `eslint-plugin-import`, the `css` import will generate errors, b
 
 ## Authors
 
-- Guillermo Rauch ([@rauchg](https://twitter.com/rauchg)) - [▲ZEIT](https://zeit.co)
-- Naoyuki Kanezawa ([@nkzawa](https://twitter.com/nkzawa)) - [▲ZEIT](https://zeit.co)
+- Guillermo Rauch ([@rauchg](https://twitter.com/rauchg)) - [▲Vercel](https://vercel.com)
+- Naoyuki Kanezawa ([@nkzawa](https://twitter.com/nkzawa)) - [▲Vercel](https://vercel.com)
 - Giuseppe Gurgone ([@giuseppegurgone](https://twitter.com/giuseppegurgone))


### PR DESCRIPTION
[Zeit is now Vercel](https://vercel.com/blog/zeit-is-now-vercel).
This PR replaces the old name in some places where it's possible.